### PR TITLE
Account for the new `generic` role in ARIA 1.2

### DIFF
--- a/src/util/isNonInteractiveElement.js
+++ b/src/util/isNonInteractiveElement.js
@@ -26,6 +26,9 @@ const nonInteractiveRoles = new Set(roleKeys
         // 'toolbar' does not descend from widget, but it does support
         // aria-activedescendant, thus in practice we treat it as a widget.
         && name !== 'toolbar'
+        // This role is meant to have no semantic value.
+        // @see https://www.w3.org/TR/wai-aria-1.2/#generic
+        && name !== 'generic'
         && !role.superClass.some((classes) => includes(classes, 'widget'))
     );
   }).concat(
@@ -42,6 +45,9 @@ const interactiveRoles = new Set(roleKeys
       // The `progressbar` is descended from `widget`, but in practice, its
       // value is always `readonly`, so we treat it as a non-interactive role.
         && name !== 'progressbar'
+        // This role is meant to have no semantic value.
+        // @see https://www.w3.org/TR/wai-aria-1.2/#generic
+        && name !== 'generic'
         && role.superClass.some((classes) => includes(classes, 'widget'))
     );
   }).concat(


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-1.2/#generic

>A nameless container element that has no semantic meaning on its own.
>
>Contrast with group, which semantically groups its descendants in a named container.
>
>A generic can provide a limited number of accessible states and properties for its descendants, such as aria-live attributes. This differentiates it from the presentation role.
>
>The generic role is intended for implementors of User Agents. Authors SHOULD NOT use this role in content.

Without this change, `div` and `span` elements are erroneously considered non-interactive elements. A basic assumption in the plugin up to this point is that all roles have meaning, and all roles that don't have interactive semantics, have non-interactive semantics. The `generic` role is a role without meaning, like `void`,