### PR TITLE
CHANGELOG v6.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+6.3.1 / 2020-06-19
+==================
+
+- 765da0f Update to aria-query 4.2.2
+- d528e8c Fix aria-level allowed on elements wit role heading (#704)
+- 29c6859 [meta] remove yarn registry from npmrc, so publishing works
+- f52c206 chore(package): update estraverse to version 5.0.0
+
 6.3.0 / 2020-06-18
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jsx-a11y",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
6.3.1 / 2020-06-19
==================

- 765da0f Update to aria-query 4.2.2
- d528e8c Fix aria-level allowed on elements wit role heading (#704)
- 29c6859 [meta] remove yarn registry from npmrc, so publishing works
- f52c206 chore(package): update estraverse to version 5.0.0