### PR TITLE
Add failing test for autocomplete with dynamic type

### DIFF
--- a/__tests__/src/rules/autocomplete-valid-test.js
+++ b/__tests__/src/rules/autocomplete-valid-test.js
@@ -54,6 +54,7 @@ ruleTester.run('autocomplete-valid', rule, {
     { code: '<input type="text" autocomplete="invalid name" />;', errors: invalidAutocomplete },
     { code: '<input type="text" autocomplete="home url" />;', errors: invalidAutocomplete },
     { code: '<Bar autocomplete="baz"></Bar>;', errors: invalidAutocomplete, options: [{ inputComponents: ['Bar'] }] },
+    { code: '<input type={isEmail ? "email" : "text"} autocomplete="none" />;', errors: invalidAutocomplete },
 
     // FAILED "autocomplete-appropriate"
     { code: '<input type="date" autocomplete="email" />;', errors: inappropriateAutocomplete },

--- a/src/rules/autocomplete-valid.js
+++ b/src/rules/autocomplete-valid.js
@@ -35,12 +35,13 @@ module.exports = {
         return;
       }
 
+      const type = getLiteralPropValue(getProp(node.attributes, 'type'));
       const { violations } = runVirtualRule('autocomplete-valid', {
         nodeName: 'input',
         attributes: {
           autocomplete,
           // Which autocomplete is valid depends on the input type
-          type: getLiteralPropValue(getProp(node.attributes, 'type')),
+          type: type === null ? undefined : type,
         },
       });
 


### PR DESCRIPTION
This will cause axe to throw an error like:

> TypeError: Cannot read property 'replace' of null

I believe that the problem might be related to getLiteralPropValue
returning `null` instead of `undefined` for dynamic props.