### PR TITLE
Allow `title` attribute or `aria-label` attribute instead of accessible child in the "anchor-has-content" rule

### DIFF
--- a/__tests__/src/rules/anchor-has-content-test.js
+++ b/__tests__/src/rules/anchor-has-content-test.js
@@ -36,6 +36,9 @@ ruleTester.run('anchor-has-content', rule, {
       code: '<Link>foo</Link>',
       settings: { 'jsx-a11y': { components: { Link: 'a' } } },
     },
+    { code: '<a title={title} />' },
+    { code: '<a aria-label={ariaLabel} />' },
+    { code: '<a title={title} aria-label={ariaLabel} />' },
   ].map(parserOptionsMapper),
   invalid: [
     { code: '<a />', errors: [expectedError] },

--- a/docs/rules/anchor-has-content.md
+++ b/docs/rules/anchor-has-content.md
@@ -6,6 +6,8 @@
 
 Enforce that anchors have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the `aria-hidden` prop. Refer to the references to learn about why this is important.
 
+Alternatively, you may use the `title` prop or the `aria-label` prop.
+
 ## Rule options
 
 This rule takes one optional object argument of type object:
@@ -45,6 +47,8 @@ return (
 <a>Anchor Content!</a>
 <a><TextWrapper /></a>
 <a dangerouslySetInnerHTML={{ __html: 'foo' }} />
+<a title='foo' />
+<a aria-label='foo' />
 ```
 
 ### Fail

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -7,6 +7,8 @@
 // Rule Definition
 // ----------------------------------------------------------------------------
 
+import { hasAnyProp } from 'jsx-ast-utils';
+
 import getElementType from '../util/getElementType';
 import { arraySchema, generateObjSchema } from '../util/schemas';
 import hasAccessibleChild from '../util/hasAccessibleChild';
@@ -38,6 +40,9 @@ export default {
           return;
         }
         if (hasAccessibleChild(node.parent, elementType)) {
+          return;
+        }
+        if (hasAnyProp(node.attributes, ['title', 'aria-label'])) {
           return;
         }
 


### PR DESCRIPTION
Fixes #423 

Allowed `title` and `aria-label` attributes instead of text content in the "anchor-has-content" rule.