### PR TITLE
Turn off label-has-for in strict rule set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,7 @@ module.exports = {
             ],
           },
         ],
-        'jsx-a11y/label-has-for': 'error',
+        'jsx-a11y/label-has-for': 'off',
         'jsx-a11y/label-has-associated-control': 'error',
         'jsx-a11y/media-has-caption': 'error',
         'jsx-a11y/mouse-events-have-key-events': 'error',


### PR DESCRIPTION
`label-has-for` has been deprecated and is already turned off in the recommended rule set.
Context: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md

Feel free to close this PR if it was intentional to leave `label-has-for` turned on in the strict rule set.

Closes #751.