### PR TITLE
Update recommended config to allow fieldset to have the radiogroup role

### DIFF
--- a/__tests__/src/rules/no-noninteractive-element-to-interactive-role-test.js
+++ b/__tests__/src/rules/no-noninteractive-element-to-interactive-role-test.js
@@ -448,6 +448,8 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
     { code: '<li role="row" />;' },
     { code: '<li role="treeitem" />;' },
     { code: '<Component role="treeitem" />;' },
+    { code: '<fieldset role="radiogroup" />;' },
+    { code: '<fieldset role="presentation" />;' },
   ]
     .map(ruleOptionsMapperFactory(recommendedOptions))
     .map(parserOptionsMapper),

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,7 @@ module.exports = {
             li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
             table: ['grid'],
             td: ['gridcell'],
+            fieldset: ['radiogroup', 'presentation'],
           },
         ],
         'jsx-a11y/no-noninteractive-tabindex': [


### PR DESCRIPTION
###  Description
Update the recommended config to allow `fieldset` to have the `radiogroup` role. Also update the test for this rule to have an entry for this change and one for the `presentation` role.

[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset) lists both `radiogroup` and `presentation` as valid options for the role attribute on a `fieldset`.

This fixes https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/743.

### Testing
1. Pull this branch (or apply these changes as a patch)
2. Run `npm i`
3. Run `npm run test`, no tests should fail