### PR TITLE
Correct 'recommended' vs 'strict' table

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Rule | Recommended | Strict
 [img-redundant-alt](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md) | error | error
 [interactive-supports-focus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md) | error | error
 [label-has-associated-control](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md) | error | error
+[label-has-for](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) | off | error
 [media-has-caption](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md) | error | error
 [mouse-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md) | error | error
 [no-access-key](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md) | error | error


### PR DESCRIPTION
Looking at [this line](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.3.1/src/index.js#L268), I can see that in "recommended" mode, "label-has-for" is set to "off." However, in "strict" mode, it is set to "error."

Although, maybe it should be set to "off" in both cases as it's a deprecated rule?