### PR TITLE
Fully deprecate accessible-emoji rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Add `plugin:jsx-a11y/recommended` or `plugin:jsx-a11y/strict` in `extends`:
 
 ## Supported Rules
 
-- [accessible-emoji](docs/rules/accessible-emoji.md): Enforce emojis are wrapped in `<span>` and provide screenreader access.
 - [alt-text](docs/rules/alt-text.md): Enforce all elements that require alternative text have meaningful information to relay back to end user.
 - [anchor-has-content](docs/rules/anchor-has-content.md): Enforce all anchors to contain accessible content.
 - [anchor-is-valid](docs/rules/anchor-is-valid.md): Enforce all anchors are valid, navigable elements.
@@ -138,7 +137,6 @@ Add `plugin:jsx-a11y/recommended` or `plugin:jsx-a11y/strict` in `extends`:
 
 Rule | Recommended | Strict
 ------------ | ------------- | -------------
-[accessible-emoji](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md) | error | error
 [alt-text](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md) | error | error
 [anchor-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md) | error | error
 [anchor-is-valid](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md) | error | error

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,6 @@ module.exports = {
         },
       },
       rules: {
-        'jsx-a11y/accessible-emoji': 'error',
         'jsx-a11y/alt-text': 'error',
         'jsx-a11y/anchor-has-content': 'error',
         'jsx-a11y/anchor-is-valid': 'error',
@@ -206,7 +205,6 @@ module.exports = {
         },
       },
       rules: {
-        'jsx-a11y/accessible-emoji': 'error',
         'jsx-a11y/alt-text': 'error',
         'jsx-a11y/anchor-has-content': 'error',
         'jsx-a11y/anchor-is-valid': 'error',


### PR DESCRIPTION
The [accessible-emoji rule got marked as deprecated](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/713) to address https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627, but was never removed from the rule set.

This removes the rule from the strict and recommended lists and also updates the readme to reflect it being deprecated.