### PR TITLE
[Docs] Clarify the title of the strictness table in the main doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Add `plugin:jsx-a11y/recommended` or `plugin:jsx-a11y/strict` in `extends`:
 - [scope](docs/rules/scope.md): Enforce `scope` prop is only used on `<th>` elements.
 - [tabindex-no-positive](docs/rules/tabindex-no-positive.md): Enforce `tabIndex` value is not greater than zero.
 
-### Difference between 'recommended' and 'strict' mode
+### Rule strictness in different modes
 
 Rule | Recommended | Strict
 ------------ | ------------- | -------------


### PR DESCRIPTION
The heading of the section says “difference”, yet most of the rows have no difference, leading to a confusion.

Alternative implementation of #779.

Related: #238.