### PR TITLE
Support img role for canvas. Fix for #648.

### DIFF
--- a/__tests__/src/rules/no-interactive-element-to-noninteractive-role-test.js
+++ b/__tests__/src/rules/no-interactive-element-to-noninteractive-role-test.js
@@ -368,6 +368,7 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
   valid: [
     ...alwaysValid,
     { code: '<tr role="presentation" />;' },
+    { code: '<canvas role="img" />;' },
     { code: '<Component role="presentation" />;' },
   ]
     .map(ruleOptionsMapperFactory(recommendedOptions))
@@ -386,5 +387,6 @@ ruleTester.run(`${ruleName}:strict`, rule, {
   invalid: [
     ...neverValid,
     { code: '<tr role="presentation" />;', errors: [expectedError] },
+    { code: '<canvas role="img" />;', errors: [expectedError] },
   ].map(parserOptionsMapper),
 });

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ module.exports = {
           'error',
           {
             tr: ['none', 'presentation'],
+            canvas: ['img'],
           },
         ],
         'jsx-a11y/no-noninteractive-element-interactions': [


### PR DESCRIPTION
Tweaking recommendation for __no-interactive-element-to-noninteractive-role__ to support `img` role on canvas.

Fixes #648.