### PR TITLE
docs: Fix formatting typo in html-has-lang link

### DIFF
--- a/docs/rules/html-has-lang.md
+++ b/docs/rules/html-has-lang.md
@@ -1,6 +1,6 @@
 # html-has-lang
 
-<html> elements must have the lang prop. This rule is largely superseded by the [`lang` rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md).
+<html> elements must have the lang prop. This rule is largely superseded by the <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md"><code>lang</code> rule</a>.
 
 ## Rule details
 


### PR DESCRIPTION
Github isn't showing the link as a link because there's a space in it now.