### PR TITLE
fix: remove incorrect implicit role from dl

### DIFF
--- a/__tests__/src/rules/role-supports-aria-props-test.js
+++ b/__tests__/src/rules/role-supports-aria-props-test.js
@@ -425,10 +425,6 @@ ruleTester.run('role-supports-aria-props', rule, {
       errors: [errorMessage('aria-expanded', 'dialog', 'dialog', true)],
     },
     {
-      code: '<dl aria-expanded />',
-      errors: [errorMessage('aria-expanded', 'list', 'dl', true)],
-    },
-    {
       code: '<aside aria-expanded />',
       errors: [errorMessage('aria-expanded', 'complementary', 'aside', true)],
     },

--- a/src/util/implicitRoles/dl.js
+++ b/src/util/implicitRoles/dl.js
@@ -1,6 +1,0 @@
-/**
- * Returns the implicit role for a dl tag.
- */
-export default function getImplicitRoleForDl() {
-  return 'list';
-}

--- a/src/util/implicitRoles/index.js
+++ b/src/util/implicitRoles/index.js
@@ -7,7 +7,6 @@ import button from './button';
 import datalist from './datalist';
 import details from './details';
 import dialog from './dialog';
-import dl from './dl';
 import form from './form';
 import h1 from './h1';
 import h2 from './h2';
@@ -46,7 +45,6 @@ export default {
   datalist,
   details,
   dialog,
-  dl,
   form,
   h1,
   h2,


### PR DESCRIPTION
## Description

When assigning a `role` attribute to `dl`, eslint throws the following error:

```
The element dl has an implicit role of list. Defining this explicitly is redundant and should be avoided.
jsx-a11y/no-redundant-roles
```

However, based on documentation from W3 and MDN, while the `dl` element accepts a role of `list`, it's **not implicit**.

## Solution

- Remove the code that states that `dl` has an implicit role of `list`.
- Remove test for `role-supports-aria-props`

## Resources

- **W3:** [Document conformance requirements for use of ARIA attributes in HTML](https://www.w3.org/TR/html-aria/#docconformance)
- **MDN:** [\<dl\>: The Description List element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)
