### PR TITLE
fix: tabIndex="0" -> tabIndex={0}

### DIFF
--- a/docs/rules/no-static-element-interactions.md
+++ b/docs/rules/no-static-element-interactions.md
@@ -22,6 +22,7 @@ Indicate the element's role with the `role` attribute:
   onKeyPress={onKeyPressHandler}
   role="button"
   tabindex="0">
+  tabindex={0}>
   Save
 </div>
 ```


### PR DESCRIPTION
```
Type 'string' is not assignable to type 'number | undefined'.ts(2322)
index.d.ts(1835, 9): The expected type comes from property 'tabIndex' which is declared here on type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'
(JSX attribute) HTMLAttributes<HTMLDivElement>.tabIndex?: number | undefined
```