### PR TITLE
[New] support ESLint 8.x

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -25,26 +25,45 @@ jobs:
       matrix:
         node-version: ${{ fromJson(needs.matrix.outputs.latest) }}
         eslint:
+          - 8
           - 7
           - 6
           - 5
           - 4
           - 3
         exclude:
+          - node-version: 15
+            eslint: 8
+          - node-version: 13
+            eslint: 8
+          - node-version: 11
+            eslint: 8
           - node-version: 11
             eslint: 7
+          - node-version: 10
+            eslint: 8
+          - node-version: 9
+            eslint: 8
           - node-version: 9
             eslint: 7
           - node-version: 8
+            eslint: 8
+          - node-version: 8
             eslint: 7
+          - node-version: 7
+            eslint: 8
           - node-version: 7
             eslint: 7
           - node-version: 7
             eslint: 6
           - node-version: 6
+            eslint: 8
+          - node-version: 6
             eslint: 7
           - node-version: 6
             eslint: 6
+          - node-version: 5
+            eslint: 8
           - node-version: 5
             eslint: 7
           - node-version: 5
@@ -55,6 +74,8 @@ jobs:
             eslint: 4
           - node-version: 5 # TODO: fix
             eslint: 3
+          - node-version: 4
+            eslint: 8
           - node-version: 4
             eslint: 7
           - node-version: 4

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "aud": "^1.1.5",
     "babel-jest": "^24.9.0",
     "babel-preset-airbnb": "^5.0.0",
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7",
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-eslint-plugin": "^4.0.2",
-    "eslint-plugin-flowtype": "^5.8.0",
+    "eslint-plugin-flowtype": "^5.8.0 || ^8.0.2",
     "eslint-plugin-import": "^2.25.2",
     "estraverse": "^5.3.0",
     "expect": "^24.9.0",
@@ -74,7 +74,7 @@
     "minimatch": "^3.0.4"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
   },
   "jest": {
     "coverageReporters": [


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [x] [`@babel/eslint-parser`](https://github.com/babel/babel/tree/main/eslint/babel-eslint-parser) (https://github.com/babel/babel/issues/13712)
  - [x] https://github.com/babel/babel/pull/13782
  - [x] [`v7.16.0`](https://github.com/babel/babel/releases/tag/v7.16.0)
- [x] [`eslint-config-airbnb-base`](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base) (https://github.com/airbnb/javascript/issues/2478)
  - [x] https://github.com/airbnb/javascript/pull/2495
  - [x] [`v15.0.0`](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/CHANGELOG.md#1500--2021-11-08)
- [x] [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) (https://github.com/gajus/eslint-plugin-flowtype/issues/495)
  - [x] https://github.com/gajus/eslint-plugin-flowtype/commit/05c3ae13fd90c61a116eb0a5d8afd1ad7e0a3841
  - [x] [`v8.0.0`](https://github.com/gajus/eslint-plugin-flowtype/releases/tag/v8.0.0)
- [x] [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import) (https://github.com/import-js/eslint-plugin-import/issues/2211)
  - [x] https://github.com/import-js/eslint-plugin-import/pull/2191
  - [x] [`v2.25.0`](https://github.com/import-js/eslint-plugin-import/releases/tag/v2.25.0)

---

Closes #809