### PR TITLE
[fix]: Fix optional chaining bug in img-redundant-alt rule

### DIFF
--- a/__tests__/src/rules/img-redundant-alt-test.js
+++ b/__tests__/src/rules/img-redundant-alt-test.js
@@ -8,6 +8,8 @@
 // -----------------------------------------------------------------------------
 
 import { RuleTester } from 'eslint';
+import semver from 'semver';
+import { version as eslintVersion } from 'eslint/package.json';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
 import rule from '../../../src/rules/img-redundant-alt';
 
@@ -28,7 +30,7 @@ const expectedError = {
 };
 
 ruleTester.run('img-redundant-alt', rule, {
-  valid: [
+  valid: [].concat(
     { code: '<img alt="foo" />;' },
     { code: '<img alt="picture of me taking a photo of an image" aria-hidden />' },
     { code: '<img aria-hidden alt="photo of image" />' },
@@ -52,11 +54,16 @@ ruleTester.run('img-redundant-alt', rule, {
     { code: '<img alt={function(e){}} />' },
     { code: '<img aria-hidden={false} alt="Doing cool things." />' },
     { code: '<UX.Layout>test</UX.Layout>' },
-    { code: '<img alt={imageAlt} />' },
     { code: '<img alt />' },
+    { code: '<img alt={imageAlt} />' },
+    { code: '<img alt={imageAlt.name} />' },
+    semver.satisfies(eslintVersion, '>= 6') ? [
+      { code: '<img alt={imageAlt?.name} />', parserOptions: { ecmaVersion: 2020 } },
+      { code: '<img alt="Doing cool things" aria-hidden={foo?.bar}/>', parserOptions: { ecmaVersion: 2020 } },
+    ] : [],
     { code: '<img alt="Photography" />;' },
     { code: '<img alt="ImageMagick" />;' },
-  ].map(parserOptionsMapper),
+  ).map(parserOptionsMapper),
   invalid: [
     { code: '<img alt="Photo of friend." />;', errors: [expectedError] },
     { code: '<img alt="Picture of friend." />;', errors: [expectedError] },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "has": "^1.0.3",
     "jsx-ast-utils": "^3.2.1",
     "language-tags": "^1.0.5",
-    "minimatch": "^3.0.5"
+    "minimatch": "^3.0.5",
+    "semver": "^6.0.0"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"


### PR DESCRIPTION
## Description

This PR fixes an optional chaining bug in the ``img-redundant-alt`` rule. It adds valid test cases with optional chaining operator to the ``img-redundant-alt-test`` file and makes sure they have a ``parserOptions`` property for configuring parser behaviour. Along with that, it adds ``semver@6`` to ensure that tests using optional chaining skip eslint < 6

## Related Issue

Closes #794  

## Acceptance Criteria

- [x] Add test cases with optional chaining operator
- [x] Add parserOptions prop to each test case to configure parser behaviour
- [x] Add semver to tests using optional chaining to ensure they skip eslint < 6


## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| ✓ | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

