### PR TITLE
[Fix] `no-redundant-roles`, `role-supports-aria-props`: Remove implicit role from dl element

### DIFF
--- a/__tests__/src/rules/no-redundant-roles-test.js
+++ b/__tests__/src/rules/no-redundant-roles-test.js
@@ -77,6 +77,7 @@ ruleTester.run(`${ruleName}:recommended (valid list role override)`, rule, {
   valid: [
     { code: '<ul role="list" />' },
     { code: '<ol role="list" />' },
+    { code: '<dl role="list" />' },
   ]
     .map(ruleOptionsMapperFactory(listException))
     .map(parserOptionsMapper),

--- a/__tests__/src/rules/role-supports-aria-props-test.js
+++ b/__tests__/src/rules/role-supports-aria-props-test.js
@@ -433,10 +433,6 @@ ruleTester.run('role-supports-aria-props', rule, {
       errors: [errorMessage('aria-expanded', 'dialog', 'dialog', true)],
     },
     {
-      code: '<dl aria-expanded />',
-      errors: [errorMessage('aria-expanded', 'list', 'dl', true)],
-    },
-    {
       code: '<aside aria-expanded />',
       errors: [errorMessage('aria-expanded', 'complementary', 'aside', true)],
     },

--- a/src/util/implicitRoles/dl.js
+++ b/src/util/implicitRoles/dl.js
@@ -1,6 +1,0 @@
-/**
- * Returns the implicit role for a dl tag.
- */
-export default function getImplicitRoleForDl() {
-  return 'list';
-}

--- a/src/util/implicitRoles/index.js
+++ b/src/util/implicitRoles/index.js
@@ -7,7 +7,6 @@ import button from './button';
 import datalist from './datalist';
 import details from './details';
 import dialog from './dialog';
-import dl from './dl';
 import form from './form';
 import h1 from './h1';
 import h2 from './h2';
@@ -46,7 +45,6 @@ export default {
   datalist,
   details,
   dialog,
-  dl,
   form,
   h1,
   h2,


### PR DESCRIPTION
## Description

According to the [W3 documentation](https://www.w3.org/TR/html-aria/#docconformance), there is no implicit role for `dl`. This PR removes the code stating there is an implicit role of `list` for definition lists from the `no-redundant-roles-test.js` file. 

## Related Issue

Closes #847   

## Acceptance Criteria

- [x] Add a test case indicating `list` as a valid role for `dl`
- [x] Remove dl import and export from implicitRoles’ index.js file 
- [x] Remove dl.js form implicitRoles folder


## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| ✓ | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

