### PR TITLE
add `export default` instead of `module.exports`

### DIFF
--- a/scripts/boilerplate/rule.js
+++ b/scripts/boilerplate/rule.js
@@ -15,7 +15,7 @@ const errorMessage = '';
 
 const schema = generateObjSchema();
 
-module.exports = {
+export default {
   meta: {
     docs: {},
     schema: [schema],


### PR DESCRIPTION
add `export default` instead of `module.exports` in the boilerplate for `rule.js` to avoid `Cannot use import declarations in modules that export using CommonJS` errors as mentioned in the issue [#772 ](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/772)