### PR TITLE
Fix map spreading

### DIFF
--- a/src/util/isInteractiveElement.js
+++ b/src/util/isInteractiveElement.js
@@ -16,7 +16,7 @@ import attributesComparator from './attributesComparator';
 
 const domKeys = [...dom.keys()];
 const roleKeys = [...roles.keys()];
-const elementRoleEntries = [...elementRoles];
+const elementRoleEntries = [...elementRoles.entries()];
 
 const nonInteractiveRoles = new Set(roleKeys
   .filter((name) => {
@@ -81,7 +81,7 @@ const interactiveElementRoleSchemas = elementRoleEntries
 const interactiveAXObjects = new Set([...AXObjects.keys()]
   .filter((name) => AXObjects.get(name).type === 'widget'));
 
-const interactiveElementAXObjectSchemas = [...elementAXObjects]
+const interactiveElementAXObjectSchemas = [...elementAXObjects.entries()]
   .reduce((
     accumulator,
     [


### PR DESCRIPTION
Getting this error in ESLint, which seems perfectly valid:

```
Invalid attempt to spread non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
Referenced from: .../.eslintrc.cjs
    at _nonIterableSpread (.../.yarn/cache/@babel-runtime-npm-7.18.6-e238904aef-8b707b64ae.zip/node_modules/@babel/runtime/helpers/nonIterableSpread.js:2:9)
    at _toConsumableArray (.../.yarn/cache/@babel-runtime-npm-7.18.6-e238904aef-8b707b64ae.zip/node_modules/@babel/runtime/helpers/toConsumableArray.js:10:95)
    at Object.<anonymous> (.../.yarn/__virtual__/eslint-plugin-jsx-a11y-virtual-70ad45934f/7/.../.yarn/cache/eslint-plugin-jsx-a11y-npm-6.6.0-d57094bb84-d9da9a3ec7.zip/node_modules/eslint-plugin-jsx-a11y/lib/util/isInteractiveElement.js:24:61)
```

`isInteractiveElement` has a couple of instances of `[...someMap]`, where the map is not a literal `Map` object, but instead is [a vanilla object with a couple of hand-written Map prototype methods](https://github.com/A11yance/aria-query/blob/main/src/elementRoleMap.js#L58).

This package then uses Babel to transpile the spread operator, and that very Babel transpilation throws an error that said object cannot be spread.

An alternative solution could be to add the `[Symbol.iterator]()` method to the faux maps, but this seems more explicitly accurate and faster than nested dependency changes. I used `entries()` because `[...new Map()]` returns an array of the map's entries.