### PR TITLE
`iframe` and `img` tags accepts `onload` handlers

### DIFF
--- a/__tests__/src/rules/no-noninteractive-element-interactions-test.js
+++ b/__tests__/src/rules/no-noninteractive-element-interactions-test.js
@@ -139,6 +139,19 @@ const alwaysValid = [
   },
   { code: '<img {...props} onError={() => {}} />;' },
   { code: '<img onLoad={() => {}} />;' },
+  { code: '<img src={currentPhoto.imageUrl} onLoad={this.handleImageLoad} alt="for review" />' },
+  {
+    code: `
+        <img
+        ref={this.ref}
+        className="c-responsive-image-placeholder__image"
+        src={src}
+        alt={alt}
+        data-test-id="test-id"
+        onLoad={this.fetchCompleteImage}
+      />
+    `,
+  },
   { code: '<ins onClick={() => {}} />;' },
   { code: '<kbd onClick={() => {}} />;' },
   { code: '<keygen onClick={() => {}} />;' },


### PR DESCRIPTION
added test cases that resolves the Issue [474](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/474)