### PR TITLE
[Deps]: Bump aria-query version to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "aria-query": "^4.2.2",
+    "aria-query": "^5.0.0",
     "array-includes": "^3.1.5",
     "ast-types-flow": "^0.0.7",
     "axe-core": "^4.4.3",


### PR DESCRIPTION
This PR updates the `aria-query` dependency to `^5.0.0` to add support for `aria-valuenow`, `aria-valuemin` and `aria-valuemax` for `role="separator"`.

It aims to fix issue #577.