### PR TITLE
Flag `aria-label` and `aria-labelledby` on non-interactive elements

### DIFF
--- a/__tests__/src/rules/role-supports-aria-props-test.js
+++ b/__tests__/src/rules/role-supports-aria-props-test.js
@@ -579,5 +579,13 @@ ruleTester.run('role-supports-aria-props', rule, {
       code: '<span aria-labelledby />',
       errors: [errorMessage('aria-labelledby', 'generic', 'span', true)],
     },
+    {
+      code: '<div aria-label />',
+      errors: [errorMessage('aria-label', 'generic', 'div', true)],
+    },
+    {
+      code: '<div aria-labelledby />',
+      errors: [errorMessage('aria-labelledby', 'generic', 'div', true)],
+    },
   ].concat(invalidTests).map(parserOptionsMapper),
 });

--- a/__tests__/src/rules/role-supports-aria-props-test.js
+++ b/__tests__/src/rules/role-supports-aria-props-test.js
@@ -50,11 +50,14 @@ const nonAbstractRoles = [...roles.keys()].filter((role) => roles.get(role).abst
 const createTests = (rolesNames) => rolesNames.reduce((tests, role) => {
   const {
     props: propKeyValues,
+    prohibitedProps,
   } = roles.get(role);
-  const validPropsForRole = Object.keys(propKeyValues);
+  const validPropsForRole = Object.keys(propKeyValues)
+    .filter((attribute) => prohibitedProps.indexOf(attribute) === -1);
   const invalidPropsForRole = [...aria.keys()]
     .map((attribute) => attribute.toLowerCase())
-    .filter((attribute) => validPropsForRole.indexOf(attribute) === -1);
+    .filter((attribute) => validPropsForRole.indexOf(attribute) === -1)
+    .concat(prohibitedProps);
   const normalRole = role.toLowerCase();
 
   const allTests = [];
@@ -567,6 +570,14 @@ ruleTester.run('role-supports-aria-props', rule, {
       code: '<Link href="#" aria-checked />',
       errors: [errorMessage('aria-checked', 'link', 'a', true)],
       settings: componentsSettings,
+    },
+    {
+      code: '<span aria-label />',
+      errors: [errorMessage('aria-label', 'generic', 'span', true)],
+    },
+    {
+      code: '<span aria-labelledby />',
+      errors: [errorMessage('aria-labelledby', 'generic', 'span', true)],
     },
   ].concat(invalidTests).map(parserOptionsMapper),
 });

--- a/__tests__/src/util/getComputedRole-test.js
+++ b/__tests__/src/util/getComputedRole-test.js
@@ -24,7 +24,7 @@ describe('getComputedRole', () => {
       describe('lacks implicit', () => {
         it('should return null', () => {
           expect(getComputedRole(
-            'div',
+            'custom-element',
             [JSXAttributeMock('role', 'beeswax')],
           )).toBeNull();
         });
@@ -43,7 +43,7 @@ describe('getComputedRole', () => {
       describe('lacks implicit', () => {
         it('should return null', () => {
           expect(getComputedRole(
-            'div',
+            'custom-element',
             [],
           )).toBeNull();
         });
@@ -62,7 +62,7 @@ describe('getComputedRole', () => {
     describe('lacks implicit', () => {
       it('should return null', () => {
         expect(getComputedRole(
-          'div',
+          'custom-element',
           [],
         )).toBeNull();
       });

--- a/__tests__/src/util/getExplicitRole-test.js
+++ b/__tests__/src/util/getExplicitRole-test.js
@@ -14,7 +14,7 @@ describe('getExplicitRole', () => {
   describe('invalid role', () => {
     it('should return null', () => {
       expect(getExplicitRole(
-        'div',
+        'custom-element',
         [JSXAttributeMock('role', 'beeswax')],
       )).toBeNull();
     });
@@ -22,7 +22,7 @@ describe('getExplicitRole', () => {
   describe('no role', () => {
     it('should return null', () => {
       expect(getExplicitRole(
-        'div',
+        'custom-element',
         [],
       )).toBeNull();
     });

--- a/__tests__/src/util/getImplicitRole-test.js
+++ b/__tests__/src/util/getImplicitRole-test.js
@@ -13,7 +13,7 @@ describe('getImplicitRole', () => {
   describe('lacks implicit', () => {
     it('should return null', () => {
       expect(getImplicitRole(
-        'div',
+        'custom-element',
         [],
       )).toBeNull();
     });

--- a/src/rules/role-supports-aria-props.js
+++ b/src/rules/role-supports-aria-props.js
@@ -65,9 +65,11 @@ export default {
         // Make sure it has no aria-* properties defined outside of its property set.
         const {
           props: propKeyValues,
+          prohibitedProps,
         } = roles.get(roleValue);
         const invalidAriaPropsForRole = [...aria.keys()]
-          .filter((attribute) => !(attribute in propKeyValues));
+          .filter((attribute) => !(attribute in propKeyValues))
+          .concat(prohibitedProps);
 
         node.attributes.filter((prop) => (
           getPropValue(prop) != null // Ignore the attribute if its value is null or undefined.

--- a/src/util/implicitRoles/div.js
+++ b/src/util/implicitRoles/div.js
@@ -1,0 +1,6 @@
+/**
+ * Returns the implicit role for a div tag.
+ */
+export default function getImplicitRoleForDiv() {
+  return 'generic';
+}

--- a/src/util/implicitRoles/index.js
+++ b/src/util/implicitRoles/index.js
@@ -7,6 +7,7 @@ import button from './button';
 import datalist from './datalist';
 import details from './details';
 import dialog from './dialog';
+import div from './div';
 import form from './form';
 import h1 from './h1';
 import h2 from './h2';
@@ -46,6 +47,7 @@ export default {
   datalist,
   details,
   dialog,
+  div,
   form,
   h1,
   h2,

--- a/src/util/implicitRoles/index.js
+++ b/src/util/implicitRoles/index.js
@@ -29,6 +29,7 @@ import output from './output';
 import progress from './progress';
 import section from './section';
 import select from './select';
+import span from './span';
 import tbody from './tbody';
 import textarea from './textarea';
 import tfoot from './tfoot';
@@ -67,6 +68,7 @@ export default {
   progress,
   section,
   select,
+  span,
   tbody,
   textarea,
   tfoot,

--- a/src/util/implicitRoles/span.js
+++ b/src/util/implicitRoles/span.js
@@ -1,0 +1,6 @@
+/**
+ * Returns the implicit role for a span tag.
+ */
+export default function getImplicitRoleForSpan() {
+  return 'generic';
+}


### PR DESCRIPTION
### What does this PR accomplish?

Fixes https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/910

This PR indicates an error in markup like `<span aria-label="Hello, world!">Hello</span>`.

### Why?

`span` and `div` elements implicitly have the `generic` role, and `generic` prohibits `aria-label` and `aria-labelledby`.

From the [`generic` role spec](https://w3c.github.io/aria/#generic):
> The `generic` role is intended for use as the implicit role of generic elements in host languages (such as HTML `div` or `span`)
>
> […]
>
> Prohibited States and Properties: `aria-label`, `aria-labelledby`

### Implementation details

Previously, neither `div` nor `span` had an implicitly role defined in `src/util/implicitRoles/`, so the codepath in [src/rules/role-supports-aria-props.js#L55-L63](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/role-supports-aria-props.js#L55-L63) was taken, which _“assume[s] that the element can handle the global set of aria-* properties.”_ This is not a correct assumption, so I added `src/util/implicitRoles/div.js` and `src/util/implicitRoles/span.js` and re-exported them from the `src/util/implicitRoles/index.js` barrel.

Once the [src/rules/role-supports-aria-props.js#L65-L70](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/role-supports-aria-props.js#L65-L70) codepath was taken, I discovered that the list of a role’s [`prohibitedProps`](https://github.com/A11yance/aria-query/blob/main/src/etc/roles/literal/genericRole.js#L12-L15) was unused, so I concatenated it to the existing list of [`invalidAriaPropsForRole`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/role-supports-aria-props.js#L69-L70).

Next, I discovered that the list of [`validTests`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/role-supports-aria-props-test.js#L74), tests expected to pass without errors, included e.g. `<div role="superscript" aria-label />`. This initially confused me, since `aria-label` is one of [`superscript`’s `prohibitedProps`](https://github.com/A11yance/aria-query/blob/main/src/etc/roles/literal/superscriptRole.js#L12-L15). I traced this to the superclass—[`roletype` includes `aria-label`](https://github.com/A11yance/aria-query/blob/main/src/etc/roles/abstract/roletypeRole.js#L23-L24)—then added a filter to remove them.

Finally, the addition of `src/util/implicitRoles/div.js` broke a few role-related tests that assumed `div` would not have an explicit or implicit role. I replaced `div` with a made-up custom element named `custom-element`, which functions the way `div` did before this PR (i.e. lacking explicit and implicit roles).

### Testing details

I ran `npm test` locally, and all tests pass:

```sh
Test Suites: 65 passed, 65 total
Tests:       16078 passed, 16078 total
Snapshots:   0 total
Time:        40.463s, estimated 43s
```