### PR TITLE
[Deps] pin `language-tags` to `v1.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "emoji-regex": "^9.2.2",
     "has": "^1.0.3",
     "jsx-ast-utils": "^3.3.3",
-    "language-tags": "^1.0.5",
+    "language-tags": "=1.0.5",
     "minimatch": "^3.1.2",
     "semver": "^6.3.0"
   },


### PR DESCRIPTION
Technically this is just >=12, which can include versions like 13 that are no longer supported (https://github.com/nodejs/release#release-schedule). But I figured I'd keep using the existing action to get Node versions.

Fixes #914.