### PR TITLE
[Fix] `control-has-associated-label`: don't accept whitespace as an accessible label (Fixes #918)

### DIFF
--- a/__tests__/src/util/mayHaveAccessibleLabel-test.js
+++ b/__tests__/src/util/mayHaveAccessibleLabel-test.js
@@ -41,6 +41,14 @@ describe('mayHaveAccessibleLabel', () => {
         JSXAttributeMock('aria-label', ''),
       ], []))).toBe(false);
     });
+    it('aria-label with only whitespace, should return false', () => {
+      expect(mayHaveAccessibleLabel(JSXElementMock('div', [
+        JSXAttributeMock('aria-label', ' '),
+      ], []))).toBe(false);
+      expect(mayHaveAccessibleLabel(JSXElementMock('div', [
+        JSXAttributeMock('aria-label', '\n'),
+      ], []))).toBe(false);
+    });
     it('aria-labelledby, should return true', () => {
       expect(mayHaveAccessibleLabel(JSXElementMock('div', [
         JSXAttributeMock('aria-labelledby', 'elementId'),
@@ -77,6 +85,14 @@ describe('mayHaveAccessibleLabel', () => {
       expect(mayHaveAccessibleLabel(JSXElementMock('div', [], [
         LiteralMock('A fancy label'),
       ]))).toBe(true);
+    });
+    it('Literal whitespace, should return false', () => {
+      expect(mayHaveAccessibleLabel(JSXElementMock('div', [], [
+        LiteralMock(' '),
+      ]))).toBe(false);
+      expect(mayHaveAccessibleLabel(JSXElementMock('div', [], [
+        LiteralMock('\n'),
+      ]))).toBe(false);
     });
     it('JSXText, should return true', () => {
       expect(mayHaveAccessibleLabel(JSXElementMock('div', [], [

--- a/src/util/mayHaveAccessibleLabel.js
+++ b/src/util/mayHaveAccessibleLabel.js
@@ -12,6 +12,10 @@ import includes from 'array-includes';
 import { getPropValue, propName } from 'jsx-ast-utils';
 import type { JSXOpeningElement, Node } from 'ast-types-flow';
 
+function tryTrim(value: any) {
+  return typeof value === 'string' ? value.trim() : value;
+}
+
 function hasLabellingProp(
   openingElement: JSXOpeningElement,
   additionalLabellingProps?: Array<string> = [],
@@ -30,7 +34,7 @@ function hasLabellingProp(
     // Attribute matches.
     if (
       includes(labellingProps, propName(attribute))
-      && !!getPropValue(attribute)
+      && !!tryTrim(getPropValue(attribute))
     ) {
       return true;
     }
@@ -52,7 +56,7 @@ export default function mayHaveAccessibleLabel(
       return false;
     }
     // Check for literal text.
-    if (node.type === 'Literal' && !!node.value) {
+    if (node.type === 'Literal' && !!tryTrim(node.value)) {
       return true;
     }
     // Assume an expression container renders a label. It is the best we can
@@ -62,7 +66,7 @@ export default function mayHaveAccessibleLabel(
     }
     // Check for JSXText.
     // $FlowFixMe Remove after updating ast-types-flow
-    if (node.type === 'JSXText' && !!node.value) {
+    if (node.type === 'JSXText' && !!tryTrim(node.value)) {
       return true;
     }
     // Check for labelling props.


### PR DESCRIPTION
Fixes #918