### PR TITLE
Enable no-aria-hidden-on-focusable rule in config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ module.exports = {
         'jsx-a11y/mouse-events-have-key-events': 'error',
         'jsx-a11y/no-access-key': 'error',
         'jsx-a11y/no-autofocus': 'error',
+        'jsx-a11y/no-aria-hidden-on-focusable': 'error',
         'jsx-a11y/no-distracting-elements': 'error',
         'jsx-a11y/no-interactive-element-to-noninteractive-role': [
           'error',
@@ -272,6 +273,7 @@ module.exports = {
         'jsx-a11y/mouse-events-have-key-events': 'error',
         'jsx-a11y/no-access-key': 'error',
         'jsx-a11y/no-autofocus': 'error',
+        'jsx-a11y/no-aria-hidden-on-focusable': 'error',
         'jsx-a11y/no-distracting-elements': 'error',
         'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
         'jsx-a11y/no-noninteractive-element-interactions': [


### PR DESCRIPTION
I was working on a `eslint-plugin-jsx-a11y` bump and realized this new rule, `no-aria-hidden-on-focusable`, isn't pulled in by the recommended or strict config. 

Not sure which category it should be enabled under, so I enabled it for both.