### PR TITLE
[Docs] `aria-activedescendant-has-tabindex`: align with changes from #708

### DIFF
--- a/docs/rules/aria-activedescendant-has-tabindex.md
+++ b/docs/rules/aria-activedescendant-has-tabindex.md
@@ -15,8 +15,7 @@ element will be applied as the value of `aria-activedescendant` on the input
 element.
 
 Because an element with `aria-activedescendant` must be tabbable, it must either
-have an inherent `tabIndex` of zero or declare a `tabIndex` of zero with the `tabIndex`
-attribute.
+have an inherent `tabIndex` of zero or declare a `tabIndex` attribute.
 
 ## Rule details
 
@@ -34,16 +33,16 @@ This rule takes no arguments.
 <div aria-activedescendant={someID} tabIndex={0} />
 <div aria-activedescendant={someID} tabIndex="0" />
 <div aria-activedescendant={someID} tabIndex={1} />
+<div aria-activedescendant={someID} tabIndex={-1} />
+<div aria-activedescendant={someID} tabIndex="-1" />
 <input aria-activedescendant={someID} />
 <input aria-activedescendant={someID} tabIndex={0} />
+<input aria-activedescendant={someID} tabIndex={-1} />
 ```
 
 ### Fail
 ```jsx
 <div aria-activedescendant={someID} />
-<div aria-activedescendant={someID} tabIndex={-1} />
-<div aria-activedescendant={someID} tabIndex="-1" />
-<input aria-activedescendant={someID} tabIndex={-1} />
 ```
 
 ## Accessibility guidelines


### PR DESCRIPTION
align with changes from #708
closes #924