### PR TITLE
[Dev Deps] move `semver` from Deps to Dev Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "object.assign": "^4.1.4",
     "rimraf": "^3.0.2",
     "safe-publish-latest": "^2.0.0",
+    "semver": "^6.3.1",
     "to-ast": "^1.0.0"
   },
   "engines": {
@@ -87,8 +88,7 @@
     "language-tags": "=1.0.5",
     "minimatch": "^3.1.2",
     "object.entries": "^1.1.6",
-    "object.fromentries": "^2.0.6",
-    "semver": "^6.3.1"
+    "object.fromentries": "^2.0.6"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"


### PR DESCRIPTION
Closes #943

I noticed that `semver` is actually only used in the unit test cases, so it is safe to move `semver` to the `devDependencies`.

<img width="401" alt="image" src="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/assets/40715044/b30c0a39-53ab-4c55-98fe-51cee5fc14c2">
