### PR TITLE
[Docs] `no-static-element-interactions`: `tabIndex` is written `tabindex` 

### DIFF
--- a/docs/rules/no-static-element-interactions.md
+++ b/docs/rules/no-static-element-interactions.md
@@ -21,7 +21,7 @@ Indicate the element's role with the `role` attribute:
   onClick={onClickHandler}
   onKeyPress={onKeyPressHandler}
   role="button"
-  tabIndex="0">
+  tabindex="0">
   Save
 </div>
 ```


### PR DESCRIPTION
see
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

linting will also fail if it's `tabIndex` with a capital i