### PR TITLE
Allow `menuitemradio` and `menuitemcheckbox` on <li>

### DIFF
--- a/__tests__/src/rules/no-noninteractive-element-to-interactive-role-test.js
+++ b/__tests__/src/rules/no-noninteractive-element-to-interactive-role-test.js
@@ -457,6 +457,8 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
     { code: '<ol role="treegrid" />;' },
     { code: '<li role="tab" />;' },
     { code: '<li role="menuitem" />;' },
+    { code: '<li role="menuitemcheckbox" />;' },
+    { code: '<li role="menuitemradio" />;' },
     { code: '<li role="row" />;' },
     { code: '<li role="treeitem" />;' },
     { code: '<Component role="treeitem" />;' },

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ module.exports = {
               'tree',
               'treegrid',
             ],
-            li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
+            li: ['menuitem', 'menuitemradio', 'menuitemcheckbox', 'option', 'row', 'tab', 'treeitem'],
             table: ['grid'],
             td: ['gridcell'],
             fieldset: ['radiogroup', 'presentation'],


### PR DESCRIPTION
Fixes: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/896

Currently, the `jsx-a11y/no-noninteractive-element-to-interactive-role` rule flags `<li role="menuitemradio">` and `<li role="menuitemcheckbox">`. I don't think these should be flagged, especially given we allow `<li role="menuitem">`.

Conflicting recommendations:
* [Editor Menubar Example | APG | WAI | W3C](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/) has an example markup with `<li role="menuitemradio">`. 
* [WAI -ARIA 1.2 Example](https://www.w3.org/TR/wai-aria-1.2/#example-2)
* [WAI-ARIA 1.4 Example](https://www.w3.org/TR/wai-aria-1.2/#example-4)