### PR TITLE
remove object.assign

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "max-len": "off",
     "no-template-curly-in-string": "off",
+    "prefer-object-spread": "off"
   },
   "overrides": [
     {

--- a/__tests__/src/rules/label-has-for-test.js
+++ b/__tests__/src/rules/label-has-for-test.js
@@ -8,7 +8,6 @@
 // -----------------------------------------------------------------------------
 
 import { RuleTester } from 'eslint';
-import assign from 'object.assign';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
 import parsers from '../../__util__/helpers/parsers';
 import rule from '../../../src/rules/label-has-for';
@@ -63,18 +62,18 @@ ruleTester.run('label-has-for', rule, {
     { code: '<UX.Layout>test</UX.Layout>' },
 
     // CUSTOM ELEMENT ARRAY OPTION TESTS
-    { code: '<Label htmlFor="foo" />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Label htmlFor={"foo"} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Label htmlFor={foo} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Label htmlFor={`${id}`} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Label htmlFor="foo" />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Label htmlFor={"foo"} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Label htmlFor={foo} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Label htmlFor={`${id}`} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
     { code: '<div />', options: optionsComponents },
     { code: '<Label htmlFor="something"><input /></Label>', options: optionsComponents },
-    { code: '<Label htmlFor="foo">Test!</Label>', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Descriptor htmlFor="foo" />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Descriptor htmlFor={"foo"} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Descriptor htmlFor={foo} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Descriptor htmlFor={`${id}`} />', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
-    { code: '<Descriptor htmlFor="foo">Test!</Descriptor>', options: [assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Label htmlFor="foo">Test!</Label>', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Descriptor htmlFor="foo" />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Descriptor htmlFor={"foo"} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Descriptor htmlFor={foo} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Descriptor htmlFor={`${id}`} />', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
+    { code: '<Descriptor htmlFor="foo">Test!</Descriptor>', options: [Object.assign({}, optionsComponents[0], optionsRequiredSome[0])] },
     { code: '<label htmlFor="foo" />', options: optionsRequiredSome },
     { code: '<label htmlFor={"foo"} />', options: optionsRequiredSome },
     { code: '<label htmlFor={foo} />', options: optionsRequiredSome },
@@ -84,7 +83,7 @@ ruleTester.run('label-has-for', rule, {
     { code: '<label><input /></label>', options: optionsRequiredNesting },
     { code: '<label htmlFor="input"><input /></label>', options: optionsRequiredEvery },
     { code: '<label><input /></label>', options: optionsChildrenAllowed },
-    { code: '<Descriptor htmlFor="foo">Test!</Descriptor>', options: [assign({}, optionsComponents, optionsChildrenAllowed)] },
+    { code: '<Descriptor htmlFor="foo">Test!</Descriptor>', options: [Object.assign({}, optionsComponents, optionsChildrenAllowed)] },
     { code: '<label>Test!</label>', options: optionsChildrenAllowed },
     { code: '<label htmlFor="foo">Test!</label>', options: optionsChildrenAllowed },
     { code: '<label>{children}</label>', options: optionsChildrenAllowed },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jscodeshift": "^0.7.1",
     "minimist": "^1.2.8",
     "npmignore": "^0.3.0",
-    "object.assign": "^4.1.4",
     "rimraf": "^3.0.2",
     "safe-publish-latest": "^2.0.0",
     "semver": "^6.3.1",


### PR DESCRIPTION
I found that Object.assign is already supported in Node.js 4.0.0, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign. So removed object.assign package and opted to Object.assign. Also I had to turn eslint rule because spread operator it not supported on Node.js 4.

I would like to propose to raise Node.js version requirement, maybe up to 16.13.0, then remove polyfills to reduce install size. I would like to help with this.

Here are polyfills and Node.js versions what supports these features. 

| Dependency |Node.js version|
|-------------------------|------|
| array-includes | 6.0.0 |
| object.entries | 7.0.0 |
| array.prototype.flatmap | 11.0.0 |
| object.fromentries | 12.0.0 |
| hasown | 16.9.0 |


