### PR TITLE
remove array-includes

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           versionsAsRoot: true
           type: 'majors'
-          preset: '>=4'
+          preset: '>=6'
 
   latest:
     needs: [matrix]
@@ -28,9 +28,6 @@ jobs:
           - 8
           - 7
           - 6
-          - 5
-          - 4
-          - 3
         exclude:
           - node-version: 15
             eslint: 8
@@ -62,30 +59,6 @@ jobs:
             eslint: 7
           - node-version: 6
             eslint: 6
-          - node-version: 5
-            eslint: 8
-          - node-version: 5
-            eslint: 7
-          - node-version: 5
-            eslint: 6
-          - node-version: 5
-            eslint: 5
-          - node-version: 5
-            eslint: 4
-          - node-version: 5 # TODO: fix
-            eslint: 3
-          - node-version: 4
-            eslint: 8
-          - node-version: 4
-            eslint: 7
-          - node-version: 4
-            eslint: 6
-          - node-version: 4
-            eslint: 5
-          - node-version: 4 # TODO: fix
-            eslint: 4
-          - node-version: 4 # TODO: fix
-            eslint: 3
 
     steps:
       - uses: actions/checkout@v3

--- a/__mocks__/genInteractives.js
+++ b/__mocks__/genInteractives.js
@@ -3,7 +3,6 @@
  */
 
 import { dom, roles } from 'aria-query';
-import includes from 'array-includes';
 import fromEntries from 'object.fromentries';
 
 import JSXAttributeMock from './JSXAttributeMock';
@@ -140,17 +139,17 @@ const interactiveRoles = []
   )
   .filter((role) => (
     !roles.get(role).abstract
-    && roles.get(role).superClass.some((klasses) => includes(klasses, 'widget'))
+    && roles.get(role).superClass.some((klasses) => klasses.includes('widget'))
   ));
 
 const nonInteractiveRoles = roleNames
   .filter((role) => (
     !roles.get(role).abstract
-    && !roles.get(role).superClass.some((klasses) => includes(klasses, 'widget'))
+    && !roles.get(role).superClass.some((klasses) => klasses.includes('widget'))
 
     // 'toolbar' does not descend from widget, but it does support
     // aria-activedescendant, thus in practice we treat it as a widget.
-    && !includes(['toolbar'], role)
+    && !['toolbar'].includes(role)
   ));
 
 export function genElementSymbol(openingElement: Object): string {

--- a/__tests__/src/rules/interactive-supports-focus-test.js
+++ b/__tests__/src/rules/interactive-supports-focus-test.js
@@ -7,7 +7,6 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-import includes from 'array-includes';
 import { RuleTester } from 'eslint';
 import {
   eventHandlers,
@@ -213,12 +212,12 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
     ...alwaysValid,
     ...passReducer(
       interactiveRoles,
-      eventHandlers.filter((handler) => !includes(triggeringHandlers, handler)),
+      eventHandlers.filter((handler) => !triggeringHandlers.includes(handler)),
       codeTemplate,
     ),
     ...passReducer(
-      interactiveRoles.filter((role) => !includes(recommendedRoles, role)),
-      eventHandlers.filter((handler) => includes(triggeringHandlers, handler)),
+      interactiveRoles.filter((role) => !recommendedRoles.includes(role)),
+      eventHandlers.filter((handler) => triggeringHandlers.includes(handler)),
       tabindexTemplate,
     ),
   ))
@@ -228,7 +227,7 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
     ...neverValid,
     ...failReducer(recommendedRoles, triggeringHandlers, tabbableTemplate),
     ...failReducer(
-      interactiveRoles.filter((role) => !includes(recommendedRoles, role)),
+      interactiveRoles.filter((role) => !recommendedRoles.includes(role)),
       triggeringHandlers,
       focusableTemplate,
     ),
@@ -242,12 +241,12 @@ ruleTester.run(`${ruleName}:strict`, rule, {
     ...alwaysValid,
     ...passReducer(
       interactiveRoles,
-      eventHandlers.filter((handler) => !includes(triggeringHandlers, handler)),
+      eventHandlers.filter((handler) => !triggeringHandlers.includes(handler)),
       codeTemplate,
     ),
     ...passReducer(
-      interactiveRoles.filter((role) => !includes(strictRoles, role)),
-      eventHandlers.filter((handler) => includes(triggeringHandlers, handler)),
+      interactiveRoles.filter((role) => !strictRoles.includes(role)),
+      eventHandlers.filter((handler) => triggeringHandlers.includes(handler)),
       tabindexTemplate,
     ),
   ))
@@ -257,7 +256,7 @@ ruleTester.run(`${ruleName}:strict`, rule, {
     ...neverValid,
     ...failReducer(strictRoles, triggeringHandlers, tabbableTemplate),
     ...failReducer(
-      interactiveRoles.filter((role) => !includes(strictRoles, role)),
+      interactiveRoles.filter((role) => !strictRoles.includes(role)),
       triggeringHandlers,
       focusableTemplate,
     ),

--- a/package.json
+++ b/package.json
@@ -69,13 +69,12 @@
     "to-ast": "^1.0.0"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "aria-query": "^5.3.0",
-    "array-includes": "^3.1.7",
     "array.prototype.flatmap": "^1.3.2",
     "ast-types-flow": "^0.0.8",
     "axe-core": "=4.7.0",
@@ -91,7 +90,7 @@
     "object.fromentries": "^2.0.7"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+    "eslint": "^6 || ^7 || ^8"
   },
   "jest": {
     "coverageReporters": [

--- a/src/rules/control-has-associated-label.js
+++ b/src/rules/control-has-associated-label.js
@@ -11,7 +11,6 @@
 
 import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
 import type { JSXElement } from 'ast-types-flow';
-import includes from 'array-includes';
 import { generateObjSchema, arraySchema } from '../util/schemas';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import getElementType from '../util/getElementType';
@@ -68,7 +67,7 @@ export default ({
         return;
       }
       // Ignore roles that are "interactive" but should not require a label.
-      if (includes(ignoreRoles, role)) {
+      if (ignoreRoles.includes(role)) {
         return;
       }
       const props = node.openingElement.attributes;

--- a/src/rules/interactive-supports-focus.js
+++ b/src/rules/interactive-supports-focus.js
@@ -15,7 +15,6 @@ import {
   hasAnyProp,
 } from 'jsx-ast-utils';
 import type { JSXOpeningElement } from 'ast-types-flow';
-import includes from 'array-includes';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import {
   enumArraySchema,
@@ -39,7 +38,7 @@ const schema = generateObjSchema({
   // TODO: convert to use iterFilter and iterFrom
   tabbable: enumArraySchema([...roles.keys()].filter((name) => (
     !roles.get(name).abstract
-    && roles.get(name).superClass.some((klasses) => includes(klasses, 'widget'))
+    && roles.get(name).superClass.some((klasses) => klasses.includes('widget'))
   ))),
 });
 
@@ -95,7 +94,7 @@ export default ({
           && !hasTabindex
         ) {
           const role = getLiteralPropValue(getProp(attributes, 'role'));
-          if (includes(tabbable, role)) {
+          if (tabbable.includes(role)) {
             // Always tabbable, tabIndex = 0
             context.report({
               node,

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -16,7 +16,6 @@ import {
   propName,
 } from 'jsx-ast-utils';
 import type { JSXIdentifier } from 'ast-types-flow';
-import includes from 'array-includes';
 import hasOwn from 'hasown';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import type { ESLintJSXAttribute } from '../../flow/eslint-jsx';
@@ -68,7 +67,7 @@ export default ({
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (hasOwn(allowedRoles, type) && includes(allowedRoles[type], role)) {
+        if (hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -16,7 +16,6 @@ import {
   propName,
 } from 'jsx-ast-utils';
 import type { JSXOpeningElement } from 'ast-types-flow';
-import includes from 'array-includes';
 import hasOwn from 'hasown';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import { arraySchema, generateObjSchema } from '../util/schemas';
@@ -62,7 +61,7 @@ export default ({
         const interactiveProps = config.handlers || defaultInteractiveProps;
         // Allow overrides from rule configuration for specific elements and roles.
         if (hasOwn(config, type)) {
-          attributes = attributes.filter((attr) => attr.type !== 'JSXSpreadAttribute' && !includes(config[type], propName(attr)));
+          attributes = attributes.filter((attr) => attr.type !== 'JSXSpreadAttribute' && !config[type].includes(propName(attr)));
         }
 
         const hasInteractiveProps = interactiveProps

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -14,7 +14,6 @@ import {
   propName,
 } from 'jsx-ast-utils';
 import type { JSXIdentifier } from 'ast-types-flow';
-import includes from 'array-includes';
 import hasOwn from 'hasown';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import type { ESLintJSXAttribute } from '../../flow/eslint-jsx';
@@ -66,7 +65,7 @@ export default ({
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (hasOwn(allowedRoles, type) && includes(allowedRoles[type], role)) {
+        if (hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-noninteractive-tabindex.js
+++ b/src/rules/no-noninteractive-tabindex.js
@@ -14,7 +14,6 @@ import {
   getProp,
   getLiteralPropValue,
 } from 'jsx-ast-utils';
-import includes from 'array-includes';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import getElementType from '../util/getElementType';
 import isInteractiveElement from '../util/isInteractiveElement';
@@ -71,10 +70,10 @@ export default ({
           roles,
           allowExpressionValues,
         } = (options[0] || {});
-        if (tags && includes(tags, type)) {
+        if (tags && tags.includes(type)) {
           return;
         }
-        if (roles && includes(roles, role)) {
+        if (roles && roles.includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -9,7 +9,6 @@
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-import includes from 'array-includes';
 import hasOwn from 'hasown';
 import type { JSXOpeningElement } from 'ast-types-flow';
 import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
@@ -64,7 +63,7 @@ export default ({
             redundantRolesForElement = DEFAULT_ROLE_EXCEPTIONS[type] || [];
           }
 
-          if (includes(redundantRolesForElement, implicitRole)) {
+          if (redundantRolesForElement.includes(implicitRole)) {
             return;
           }
 

--- a/src/util/isInteractiveElement.js
+++ b/src/util/isInteractiveElement.js
@@ -11,7 +11,6 @@ import {
   AXObjects,
   elementAXObjects,
 } from 'axobject-query';
-import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 import iterFrom from 'es-iterator-helpers/Iterator.from';
 // import iterFlatMap from 'es-iterator-helpers/Iterator.prototype.flatMap';
@@ -31,7 +30,7 @@ const nonInteractiveRoles = new Set(roleKeys
         // 'toolbar' does not descend from widget, but it does support
         // aria-activedescendant, thus in practice we treat it as a widget.
         && name !== 'toolbar'
-        && !role.superClass.some((classes) => includes(classes, 'widget'))
+        && !role.superClass.some((classes) => classes.includes('widget'))
     );
   }).concat(
     // The `progressbar` is descended from `widget`, but in practice, its
@@ -47,7 +46,7 @@ const interactiveRoles = new Set(roleKeys
         // The `progressbar` is descended from `widget`, but in practice, its
         // value is always `readonly`, so we treat it as a non-interactive role.
         && name !== 'progressbar'
-        && role.superClass.some((classes) => includes(classes, 'widget'))
+        && role.superClass.some((classes) => classes.includes('widget'))
     );
   }).concat(
     // 'toolbar' does not descend from widget, but it does support

--- a/src/util/isInteractiveRole.js
+++ b/src/util/isInteractiveRole.js
@@ -2,13 +2,12 @@
 import { roles as rolesMap } from 'aria-query';
 import type { Node } from 'ast-types-flow';
 import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
-import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 
 const roles = [...rolesMap.keys()];
 const interactiveRoles = roles.filter((name) => (
   !rolesMap.get(name).abstract
-  && rolesMap.get(name).superClass.some((klasses) => includes(klasses, 'widget'))
+  && rolesMap.get(name).superClass.some((klasses) => klasses.includes('widget'))
 ));
 
 // 'toolbar' does not descend from widget, but it does support
@@ -42,11 +41,11 @@ const isInteractiveRole = (
   const normalizedValues = String(value).toLowerCase().split(' ');
   const validRoles = flatMap(
     normalizedValues,
-    (name: string) => (includes(roles, name) ? [name] : []),
+    (name: string) => (roles.includes(name) ? [name] : []),
   );
   if (validRoles.length > 0) {
     // The first role value is a series takes precedence.
-    isInteractive = includes(interactiveRoles, validRoles[0]);
+    isInteractive = interactiveRoles.includes(validRoles[0]);
   }
 
   return isInteractive;

--- a/src/util/isNonInteractiveElement.js
+++ b/src/util/isNonInteractiveElement.js
@@ -12,7 +12,6 @@ import {
   elementAXObjects,
 } from 'axobject-query';
 import type { Node } from 'ast-types-flow';
-import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 import iterFrom from 'es-iterator-helpers/Iterator.from';
 // import iterFlatMap from 'es-iterator-helpers/Iterator.prototype.flatMap';
@@ -39,7 +38,7 @@ const nonInteractiveRoles = new Set(roleKeys
         // treats them both as CellRole and since gridcell is interactive, we consider
         // cell interactive as well.
         && name !== 'cell'
-        && !role.superClass.some((classes) => includes(classes, 'widget'))
+        && !role.superClass.some((classes) => classes.includes('widget'))
     );
   }).concat(
     // The `progressbar` is descended from `widget`, but in practice, its
@@ -58,7 +57,7 @@ const interactiveRoles = new Set(roleKeys
         // This role is meant to have no semantic value.
         // @see https://www.w3.org/TR/wai-aria-1.2/#generic
         && name !== 'generic'
-        && role.superClass.some((classes) => includes(classes, 'widget'))
+        && role.superClass.some((classes) => classes.includes('widget'))
     );
   }).concat(
     // 'toolbar' does not descend from widget, but it does support
@@ -78,7 +77,7 @@ const nonInteractiveElementRoleSchemas = flatMap(
   ([elementSchema, rolesArr]) => (rolesArr.every((role): boolean => nonInteractiveRoles.has(role)) ? [elementSchema] : []),
 );
 
-const nonInteractiveAXObjects = new Set(filter(iterFrom(AXObjects.keys()), (name) => includes(['window', 'structure'], AXObjects.get(name).type)));
+const nonInteractiveAXObjects = new Set(filter(iterFrom(AXObjects.keys()), (name) => ['window', 'structure'].includes(AXObjects.get(name).type)));
 
 // TODO: convert to use iterFlatMap and iterFrom
 const nonInteractiveElementAXObjectSchemas = flatMap(

--- a/src/util/isNonInteractiveRole.js
+++ b/src/util/isNonInteractiveRole.js
@@ -8,12 +8,11 @@ import {
 } from 'aria-query';
 import type { Node } from 'ast-types-flow';
 import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
-import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 
 const nonInteractiveRoles = [...rolesMap.keys()].filter((name) => (
   !rolesMap.get(name).abstract
-  && !rolesMap.get(name).superClass.some((klasses) => includes(klasses, 'widget'))
+  && !rolesMap.get(name).superClass.some((klasses) => klasses.includes('widget'))
 ));
 
 /**
@@ -54,7 +53,7 @@ const isNonInteractiveRole = (
   );
   if (validRoles.length > 0) {
     // The first role value is a series takes precedence.
-    isNonInteractive = includes(nonInteractiveRoles, validRoles[0]);
+    isNonInteractive = nonInteractiveRoles.includes(validRoles[0]);
   }
 
   return isNonInteractive;

--- a/src/util/mayHaveAccessibleLabel.js
+++ b/src/util/mayHaveAccessibleLabel.js
@@ -8,7 +8,6 @@
  * @flow
  */
 
-import includes from 'array-includes';
 import { getPropValue, propName } from 'jsx-ast-utils';
 import type { JSXOpeningElement, Node } from 'ast-types-flow';
 
@@ -33,7 +32,7 @@ function hasLabellingProp(
     }
     // Attribute matches.
     if (
-      includes(labellingProps, propName(attribute))
+      labellingProps.includes(propName(attribute))
       && !!tryTrim(getPropValue(attribute))
     ) {
       return true;


### PR DESCRIPTION
let's remove support for very old version of Node.js, and array-includes polyfill. And after a while, let's release a new major version.