### PR TITLE
[Fix] `img-redundant-alt`: fixed multibyte character support

### DIFF
--- a/__tests__/src/rules/img-redundant-alt-test.js
+++ b/__tests__/src/rules/img-redundant-alt-test.js
@@ -74,6 +74,7 @@ ruleTester.run('img-redundant-alt', rule, {
     { code: '<img alt="ImageMagick" />;' },
     { code: '<Image alt="Photo of a friend" />' },
     { code: '<Image alt="Foo" />', settings: componentsSettings },
+    { code: '<img alt="画像" />', options: [{ words: ['イメージ'] }] },
   )).map(parserOptionsMapper),
   invalid: parsers.all([].concat(
     { code: '<img alt="Photo of friend." />;', errors: [expectedError] },
@@ -129,5 +130,8 @@ ruleTester.run('img-redundant-alt', rule, {
     { code: '<img alt="Word2" />;', options: array, errors: [expectedError] },
     { code: '<Image alt="Word1" />;', options: array, errors: [expectedError] },
     { code: '<Image alt="Word2" />;', options: array, errors: [expectedError] },
+
+    { code: '<img alt="イメージ" />', options: [{ words: ['イメージ'] }], errors: [expectedError] },
+    { code: '<img alt="イメージです" />', options: [{ words: ['イメージ'] }], errors: [expectedError] },
   )).map(parserOptionsMapper),
 });

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "language-tags": "^1.0.9",
     "minimatch": "^3.1.2",
     "object.entries": "^1.1.7",
-    "object.fromentries": "^2.0.7"
+    "object.fromentries": "^2.0.7",
+    "string.prototype.includes": "^2.0.0"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"


### PR DESCRIPTION
Fixes #969.

Is it possible to replace the word boundary `\b` with `\s+`? Although it has passed unit tests.

Also, it seemed more natural not to check word boundaries for multibyte characters, which may be a difficult point to handle also related to https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/417.

`(?!{)` is removed because there is no difference in the unit test results whether it is there or not.