### PR TITLE
Support `for` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Add `plugin:jsx-a11y/recommended` or `plugin:jsx-a11y/strict` in `extends`:
         "CustomButton": "button",
         "MyButton": "button",
         "RoundButton": "button"
+      },
+      "attributes": {
+        "for": ["htmlFor", "for"]
       }
     }
   }
@@ -201,6 +204,11 @@ module.exports = [
 #### Component Mapping
 
 To enable your custom components to be checked as DOM elements, you can set global settings in your configuration file by mapping each custom component name to a DOM element type.
+
+#### Attribute Mapping
+
+To configure the JSX property to use for attribute checking, you can set global settings in your configuration file by mapping each DOM attribute to the JSX property you want to check.
+For example, you may want to allow the `for` attribute in addition to the `htmlFor` attribute for checking label associations.
 
 #### Polymorphic Components
 

--- a/__tests__/src/rules/label-has-associated-control-test.js
+++ b/__tests__/src/rules/label-has-associated-control-test.js
@@ -40,11 +40,23 @@ const componentsSettings = {
   },
 };
 
+const attributesSettings = {
+  'jsx-a11y': {
+    attributes: {
+      for: ['htmlFor', 'for'],
+    },
+  },
+};
+
 const htmlForValid = [
   { code: '<label htmlFor="js_id"><span><span><span>A label</span></span></span></label>', options: [{ depth: 4 }] },
   { code: '<label htmlFor="js_id" aria-label="A label" />' },
   { code: '<label htmlFor="js_id" aria-labelledby="A label" />' },
   { code: '<div><label htmlFor="js_id">A label</label><input id="js_id" /></div>' },
+  { code: '<label for="js_id"><span><span><span>A label</span></span></span></label>', options: [{ depth: 4 }], settings: attributesSettings },
+  { code: '<label for="js_id" aria-label="A label" />', settings: attributesSettings },
+  { code: '<label for="js_id" aria-labelledby="A label" />', settings: attributesSettings },
+  { code: '<div><label for="js_id">A label</label><input id="js_id" /></div>', settings: attributesSettings },
   // Custom label component.
   { code: '<CustomLabel htmlFor="js_id" aria-label="A label" />', options: [{ labelComponents: ['CustomLabel'] }] },
   { code: '<CustomLabel htmlFor="js_id" label="A label" />', options: [{ labelAttributes: ['label'], labelComponents: ['CustomLabel'] }] },

--- a/__tests__/src/rules/label-has-for-test.js
+++ b/__tests__/src/rules/label-has-for-test.js
@@ -50,16 +50,28 @@ const optionsChildrenAllowed = [{
   allowChildren: true,
 }];
 
+const attributesSettings = {
+  'jsx-a11y': {
+    attributes: {
+      for: ['htmlFor', 'for'],
+    },
+  },
+};
+
 ruleTester.run('label-has-for', rule, {
   valid: parsers.all([].concat(
     // DEFAULT ELEMENT 'label' TESTS
     { code: '<div />' },
     { code: '<label htmlFor="foo"><input /></label>' },
     { code: '<label htmlFor="foo"><textarea /></label>' },
+    { code: '<label for="foo"><input /></label>', settings: attributesSettings },
+    { code: '<label for="foo"><textarea /></label>', settings: attributesSettings },
     { code: '<Label />' }, // lower-case convention refers to real HTML elements.
     { code: '<Label htmlFor="foo" />' },
+    { code: '<Label for="foo" />', settings: attributesSettings },
     { code: '<Descriptor />' },
     { code: '<Descriptor htmlFor="foo">Test!</Descriptor>' },
+    { code: '<Descriptor for="foo">Test!</Descriptor>', settings: attributesSettings },
     { code: '<UX.Layout>test</UX.Layout>' },
 
     // CUSTOM ELEMENT ARRAY OPTION TESTS

--- a/docs/rules/label-has-for.md
+++ b/docs/rules/label-has-for.md
@@ -13,7 +13,7 @@ Enforce label tags have associated control.
 There are two supported ways to associate a label with a control:
 
 - nesting: by wrapping a control in a label tag
-- id: by using the prop `htmlFor` as in `htmlFor=[ID of control]`
+- id: by using the prop `htmlFor` (or any configured attribute) as in `htmlFor=[ID of control]`
 
 To fully cover 100% of assistive devices, you're encouraged to validate for both nesting and id.
 

--- a/flow/eslint.js
+++ b/flow/eslint.js
@@ -10,7 +10,8 @@ export type ESLintSettings = {
   [string]: mixed,
   'jsx-a11y'?: {
     polymorphicPropName?: string,
-    components?: {[string]: string},
+    components?: { [string]: string },
+    attributes?: { for?: string[] },
   },
 }
 


### PR DESCRIPTION
This PR introduces support for `for` attribute as equivalent for the `htmlFor` property.

Related issues: #894, #961