### PR TITLE
[New] allow polymorphic linting to be restricted to specified components

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ For example, if you set the `polymorphicPropName` setting to `as` then this elem
 
 will be evaluated as an `h3`. If no `polymorphicPropName` is set, then the component will be evaluated as `Box`.
 
+To restrict polymorphic linting to specified components, additionally set `polymorphicAllowList` to an array of component names.
+
 ⚠️ Polymorphic components can make code harder to maintain; please use this feature with caution.
 
 ## Supported Rules

--- a/__tests__/src/util/getElementType-test.js
+++ b/__tests__/src/util/getElementType-test.js
@@ -106,5 +106,49 @@ test('getElementType', (t) => {
     st.end();
   });
 
+  t.test('polymorphicPropName settings and explicitly defined polymorphicAllowList in context', (st) => {
+    const elementType = getElementType({
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'asChild',
+          polymorphicAllowList: [
+            'Box',
+            'Icon',
+          ],
+          components: {
+            Box: 'div',
+            Icon: 'svg',
+          },
+        },
+      },
+    });
+
+    st.equal(
+      elementType(JSXElementMock('Spinner', [JSXAttributeMock('asChild', 'img')]).openingElement),
+      'Spinner',
+      'does not use the polymorphic prop if polymorphicAllowList is defined, but element is not part of polymorphicAllowList',
+    );
+
+    st.equal(
+      elementType(JSXElementMock('Icon', [JSXAttributeMock('asChild', 'img')]).openingElement),
+      'img',
+      'uses the polymorphic prop if it is in explicitly defined polymorphicAllowList',
+    );
+
+    st.equal(
+      elementType(JSXElementMock('Box', [JSXAttributeMock('asChild', 'span')]).openingElement),
+      'span',
+      'returns the tag name provided by the polymorphic prop, "asChild", defined in the settings instead of the component mapping tag',
+    );
+
+    st.equal(
+      elementType(JSXElementMock('Box', [JSXAttributeMock('as', 'a')]).openingElement),
+      'div',
+      'returns the tag name provided by the component mapping if the polymorphic prop, "asChild", defined in the settings is not set',
+    );
+
+    st.end();
+  });
+
   t.end();
 });

--- a/flow/eslint.js
+++ b/flow/eslint.js
@@ -9,9 +9,10 @@ export type ESLintReport = {
 export type ESLintSettings = {
   [string]: mixed,
   'jsx-a11y'?: {
-    polymorphicPropName?: string,
     components?: { [string]: string },
     attributes?: { for?: string[] },
+    polymorphicPropName?: string,
+    polymorphicAllowList?: Array<string>,
   },
 }
 

--- a/src/util/getElementType.js
+++ b/src/util/getElementType.js
@@ -4,6 +4,7 @@
 
 import type { JSXOpeningElement } from 'ast-types-flow';
 import hasOwn from 'hasown';
+import includes from 'array-includes';
 import { elementType, getProp, getLiteralPropValue } from 'jsx-ast-utils';
 
 import type { ESLintContext } from '../../flow/eslint';
@@ -11,11 +12,20 @@ import type { ESLintContext } from '../../flow/eslint';
 const getElementType = (context: ESLintContext): ((node: JSXOpeningElement) => string) => {
   const { settings } = context;
   const polymorphicPropName = settings['jsx-a11y']?.polymorphicPropName;
+  const polymorphicAllowList = settings['jsx-a11y']?.polymorphicAllowList;
+
   const componentMap = settings['jsx-a11y']?.components;
 
   return (node: JSXOpeningElement): string => {
     const polymorphicProp = polymorphicPropName ? getLiteralPropValue(getProp(node.attributes, polymorphicPropName)) : undefined;
-    const rawType = polymorphicProp ?? elementType(node);
+
+    let rawType = elementType(node);
+    if (
+      polymorphicProp
+      && (!polymorphicAllowList || includes(polymorphicAllowList, rawType))
+    ) {
+      rawType = polymorphicProp;
+    }
 
     if (!componentMap) {
       return rawType;


### PR DESCRIPTION
#### Change

This builds on the setting introduced in https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/945.

This change allows the consumer to restrict the polymorphic setting to a specified list of components via a new optional setting,`polymorphicAllowlist`. 

* When `polymorphicAllowlist` is undefined, the polymorphic prop will be used _for any components_ of the prop name specified by `polymorphicPropName` is present. 
* When `polymorphicAllowlist` is defined, then there is an additional check to make sure that components are part of the `polymorphicAllowlist` before we use the polymorphic prop specified by `polymorphicPropName`.

#### Motivation

Linting components can raise false positives when a component handles behavior that the linter has no way to know. 

For example, an `Avatar` component may render as an `img` by default and automatically render an `alt` based on a username. The linter may raise a false positive if `Avatar` is linted as an `img` for the alt text lint rule. This can be avoided by not adding the `Avatar` to the `jsx-a11y` component map. If`Avatar` (for whatever reason) explicitly has `as="img"` set, since it can also be rendered as an `svg`, it will end up automatically linted via the `polymorphicPropName` setting.

In some projects, polymorphic linting may be useful but it may be safer on utility/basic components that don't do much (e.g. a [generic `Box` element](https://mui.com/material-ui/react-box/)), rather than opening it up to any component that allows the polymorphic prop to be set. 

I acknowledge that polymorphism is not an ideal pattern that can add complexity (as warned in the README).