### PR TITLE
bug: fix summary being treated as non-interactive

### DIFF
--- a/__mocks__/genInteractives.js
+++ b/__mocks__/genInteractives.js
@@ -49,6 +49,7 @@ const interactiveElementsMap = {
   menuitem: [],
   option: [],
   select: [],
+  summary: [],
   // Whereas ARIA makes a distinction between cell and gridcell, the AXObject
   // treats them both as CellRole and since gridcell is interactive, we consider
   // cell interactive as well.

--- a/__tests__/src/rules/no-interactive-element-to-noninteractive-role-test.js
+++ b/__tests__/src/rules/no-interactive-element-to-noninteractive-role-test.js
@@ -372,6 +372,7 @@ const neverValid = [
   { code: '<select className="foo" role="listitem" />', errors: [expectedError] },
   { code: '<textarea className="foo" role="listitem" />', errors: [expectedError] },
   { code: '<tr role="listitem" />;', errors: [expectedError] },
+  { code: '<summary role="listitem" />;', errors: [expectedError] },
   /* Custom elements */
   { code: '<Link href="http://x.y.z" role="img" />', errors: [expectedError], settings: componentsSettings },
 ];

--- a/__tests__/src/rules/no-static-element-interactions-test.js
+++ b/__tests__/src/rules/no-static-element-interactions-test.js
@@ -86,6 +86,7 @@ const alwaysValid = [
   { code: '<form onClick={() => {}} />;' },
   { code: '<form onSubmit={() => {}} />;' },
   { code: '<link onClick={() => {}} href="#" />;' },
+  { code: '<summary onClick={() => {}} />;' },
   /* HTML elements attributed with an interactive role */
   { code: '<div role="button" onClick={() => {}} />;' },
   { code: '<div role="checkbox" onClick={() => {}} />;' },
@@ -339,7 +340,6 @@ const neverValid = [
   { code: '<style onClick={() => {}} />;', errors: [expectedError] },
   { code: '<sub onClick={() => {}} />;', errors: [expectedError] },
   { code: '<sup onClick={() => {}} />;', errors: [expectedError] },
-  { code: '<summary onClick={() => {}} />;', errors: [expectedError] },
   { code: '<title onClick={() => {}} />;', errors: [expectedError] },
   { code: '<track onClick={() => {}} />;', errors: [expectedError] },
   { code: '<tt onClick={() => {}} />;', errors: [expectedError] },

--- a/src/util/isInteractiveElement.js
+++ b/src/util/isInteractiveElement.js
@@ -102,7 +102,10 @@ function checkIsInteractiveElement(tagName, attributes): boolean {
   }
   // Check in elementAXObjects for AX Tree associations for this element.
   const isInteractiveAXElement = some(iterFrom(interactiveElementAXObjectSchemas), elementSchemaMatcher);
-  if (isInteractiveAXElement) {
+  if (
+    isInteractiveAXElement
+    || tagName === 'summary' // TODO: Remove this hard-coded addition once axobject-query is updated.
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/656

This ensures that `summary` is treated as an interactive element so it doesn't raise a false positive with the `no-static-element-interactions` lint rule.