### PR TITLE
[Deps] unpin `axe-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "array-includes": "^3.1.7",
     "array.prototype.flatmap": "^1.3.2",
     "ast-types-flow": "^0.0.8",
-    "axe-core": "=4.7.0",
+    "axe-core": "^4.9.1",
     "axobject-query": "^3.2.1",
     "damerau-levenshtein": "^1.0.8",
     "emoji-regex": "^9.2.2",


### PR DESCRIPTION
previously =4.7.0, now ^4.9.1

see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/989
and https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/792