### PR TITLE
[label-has-associated-control] add `button` to list of elements that can be associated with a `label`

### DIFF
--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -69,6 +69,7 @@ export default ({
         'progress',
         'select',
         'textarea',
+        'button',
       ].concat((options.controlComponents || []));
       // Prevent crazy recursion.
       const recursionDepth = Math.min(


### PR DESCRIPTION
According to [Mdn Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label), `button` is one of the elements that can be associated with `label`

This PR add `button` to the list.