### PR TITLE
include eslint@9 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "string.prototype.includes": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
   },
   "jest": {
     "coverageReporters": [


### PR DESCRIPTION
v6.9.0 supports Flat Config, but an error occurs during installation because peerDependencies does not include eslint@9. This PR adds "^9" to peerDependencies.