### PR TITLE
[readme] fix jsxA11y import name

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ export default [
 For most of the cases, you probably want to configure some of these properties yourself.
 
 ```js
-const jsxA11yRecommended = require('eslint-plugin-jsx-a11y');
+const jsxA11y = require('eslint-plugin-jsx-a11y');
 const globals = require('globals');
 
 module.exports = [


### PR DESCRIPTION
Changed so that the imported variable name matches the variable name used.