### PR TITLE
[Fix]: `label-has-associated-control`: ignore undetermined label text

### DIFF
--- a/__tests__/src/rules/label-has-associated-control-test.js
+++ b/__tests__/src/rules/label-has-associated-control-test.js
@@ -49,6 +49,8 @@ const htmlForValid = [
   // Glob support for controlComponents option.
   { code: '<CustomLabel htmlFor="js_id" aria-label="A label" />', options: [{ controlComponents: ['Custom*'] }] },
   { code: '<CustomLabel htmlFor="js_id" aria-label="A label" />', options: [{ controlComponents: ['*Label'] }] },
+  // Rule does not error if presence of accessible label cannot be determined
+  { code: '<div><label htmlFor="js_id"><CustomText /></label><input id="js_id" /></div>' },
 ];
 const nestingValid = [
   { code: '<label>A label<input /></label>' },
@@ -74,6 +76,8 @@ const nestingValid = [
   // Glob support for controlComponents option.
   { code: '<label><span>A label<CustomInput /></span></label>', options: [{ controlComponents: ['Custom*'] }] },
   { code: '<label><span>A label<CustomInput /></span></label>', options: [{ controlComponents: ['*Input'] }] },
+  // Rule does not error if presence of accessible label cannot be determined
+  { code: '<label><CustomText /><input /></label>' },
 ];
 
 const bothValid = [

--- a/src/rules/control-has-associated-label.js
+++ b/src/rules/control-has-associated-label.js
@@ -101,6 +101,8 @@ export default ({
           node,
           recursionDepth,
           labelAttributes,
+          elementType,
+          controlComponents,
         );
       }
 

--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -87,6 +87,8 @@ export default ({
         node,
         recursionDepth,
         options.labelAttributes,
+        elementType,
+        controlComponents,
       );
 
       if (hasAccessibleLabel) {


### PR DESCRIPTION
Attempt to fix #966 

The rule no longer errors if the existence of label text cannot be determined. The criteria for not being able to determine whether the text exists are, for each child of the label:

1. It is a React component
2. It has no children
3. It is not registered as a control component. Unfortunately this means it would still error if the control component itself displays text, but I didn't see a way around that

I don't think this accounts for every case, but hopefully a good starting point

I followed the convention already used by making the new parameters for `mayHaveAccessibleLabel` optional, even though they're not. I assume that was to make it easier to write the unit tests. Happy to change that though if you'd like