### PR TITLE
[Tests] `label-has-associated-control`: add additional test cases

### DIFF
--- a/__tests__/src/rules/label-has-associated-control-test.js
+++ b/__tests__/src/rules/label-has-associated-control-test.js
@@ -86,6 +86,7 @@ const nestingValid = [
   { code: '<label>foo<progress /></label>' },
   { code: '<label>foo<textarea /></label>' },
   // Custom controlComponents.
+  { code: '<label>A label<CustomInput /></label>', options: [{ controlComponents: ['CustomInput'] }] },
   { code: '<label><span>A label<CustomInput /></span></label>', options: [{ controlComponents: ['CustomInput'] }] },
   { code: '<label><span>A label<CustomInput /></span></label>', settings: componentsSettings },
   { code: '<CustomLabel><span>A label<CustomInput /></span></CustomLabel>', options: [{ controlComponents: ['CustomInput'], labelComponents: ['CustomLabel'] }] },
@@ -141,6 +142,7 @@ const nestingInvalid = [
   { code: '<label><span><span><span><span aria-label="A label" /><input /></span></span></span></label>', options: [{ depth: 5 }], errors: [expectedError] },
   { code: '<label><span><span><span><input aria-label="A label" /></span></span></span></label>', options: [{ depth: 5 }], errors: [expectedError] },
   // Custom controlComponents.
+  { code: '<label>A label<OtherCustomInput /></label>', options: [{ controlComponents: ['CustomInput'] }], errors: [expectedError] },
   { code: '<label><span>A label<CustomInput /></span></label>', options: [{ controlComponents: ['CustomInput'] }], errors: [expectedError] },
   { code: '<CustomLabel><span>A label<CustomInput /></span></CustomLabel>', options: [{ controlComponents: ['CustomInput'], labelComponents: ['CustomLabel'] }], errors: [expectedError] },
   { code: '<CustomLabel><span label="A label"><CustomInput /></span></CustomLabel>', options: [{ controlComponents: ['CustomInput'], labelComponents: ['CustomLabel'], labelAttributes: ['label'] }], errors: [expectedError] },

--- a/src/util/mayContainChildComponent.js
+++ b/src/util/mayContainChildComponent.js
@@ -35,7 +35,7 @@ export default function mayContainChildComponent(
         if (childNode.type === 'JSXExpressionContainer') {
           return true;
         }
-        // Check for comonents with the provided name.
+        // Check for components with the provided name.
         if (
           childNode.type === 'JSXElement'
           && childNode.openingElement


### PR DESCRIPTION
- Add test cases for non-nested labels with custom `controlComponents`
- Fix small typo in mayContainChildComponent util
- Closes #962