### PR TITLE
[patch] `no-redundandant-roles`: allow `<img src="*.svg" role="img" />`

### DIFF
--- a/__tests__/src/rules/aria-role-test.js
+++ b/__tests__/src/rules/aria-role-test.js
@@ -84,9 +84,8 @@ ruleTester.run('aria-role', rule, {
       code: '<Box asChild="div" role="button" />',
       settings: customDivSettings,
     },
-    {
-      code: '<svg role="graphics-document document" />',
-    },
+    { code: '<svg role="graphics-document document" />' },
+    { code: '<svg role="img" />' },
   )).concat(validTests).map(parserOptionsMapper),
 
   invalid: parsers.all([].concat(

--- a/__tests__/src/rules/no-redundant-roles-test.js
+++ b/__tests__/src/rules/no-redundant-roles-test.js
@@ -83,12 +83,16 @@ ruleTester.run(`${ruleName}:recommended (valid list role override)`, rule, {
     { code: '<ul role="list" />' },
     { code: '<ol role="list" />' },
     { code: '<dl role="list" />' },
+    { code: '<img src="example.svg" role="img" />' },
+    { code: '<svg role="img" />' },
   ))
     .map(ruleOptionsMapperFactory(listException))
     .map(parserOptionsMapper),
   invalid: parsers.all([].concat(
     { code: '<ul role="list" />', errors: [expectedError('ul', 'list')] },
     { code: '<ol role="list" />', errors: [expectedError('ol', 'list')] },
+    { code: '<img role="img" />', errors: [expectedError('img', 'img')] },
+    { code: '<img src={someVariable} role="img" />', errors: [expectedError('img', 'img')] },
   ))
     .map(parserOptionsMapper),
 });

--- a/docs/rules/no-redundant-roles.md
+++ b/docs/rules/no-redundant-roles.md
@@ -43,3 +43,4 @@ General best practice (reference resources)
 ### Resources
 
 - [ARIA Spec, ARIA Adds Nothing to Default Semantics of Most HTML Elements](https://www.w3.org/TR/using-aria/#aria-does-nothing)
+- [Identifying SVG as an image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#identifying_svg_as_an_image)

--- a/src/util/implicitRoles/img.js
+++ b/src/util/implicitRoles/img.js
@@ -10,5 +10,15 @@ export default function getImplicitRoleForImg(attributes) {
     return '';
   }
 
+  /**
+   * If the src attribute can be determined to be an svg, allow the role to be set to 'img'
+   * so that VoiceOver on Safari can be better supported.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#identifying_svg_as_an_image
+   * @see https://bugs.webkit.org/show_bug.cgi?id=216364
+   */
+  const src = getProp(attributes, 'src');
+  if (src && getLiteralPropValue(src)?.includes('.svg')) { return ''; }
+
   return 'img';
 }


### PR DESCRIPTION
Setting role="img" is a valid use case to work around a Safari bug for better accessibility when the source image is an SVG file.

This improvement does not account for variables in the `src` attribute but adds a valid exception for when we can parse the string. In addition, add valid `aria-role` test for `<svg role="img" />` to ensure no future conflicts arise.

Closes [#936](https://github.com/lb-/eslint-plugin-jsx-a11y/issues/936)

