### PR TITLE
[Refactor] don't destructure builtins

### DIFF
--- a/__mocks__/genInteractives.js
+++ b/__mocks__/genInteractives.js
@@ -10,8 +10,6 @@ import JSXElementMock from './JSXElementMock';
 import type { JSXAttributeMockType } from './JSXAttributeMock';
 import type { JSXElementMockType } from './JSXElementMock';
 
-const { fromEntries } = Object;
-
 const domElements = dom.keys();
 const roleNames = roles.keys();
 
@@ -122,7 +120,7 @@ const nonInteractiveElementsMap: {[string]: Array<{[string]: string}>} = {
   ul: [],
 };
 
-const indeterminantInteractiveElementsMap: { [key: string]: Array<any> } = fromEntries(domElements.map((name) => [name, []]));
+const indeterminantInteractiveElementsMap: { [key: string]: Array<any> } = Object.fromEntries(domElements.map((name) => [name, []]));
 
 Object.keys(interactiveElementsMap)
   .concat(Object.keys(nonInteractiveElementsMap))

--- a/__tests__/__util__/helpers/parsers.js
+++ b/__tests__/__util__/helpers/parsers.js
@@ -2,8 +2,6 @@ import path from 'path';
 import semver from 'semver';
 import { version } from 'eslint/package.json';
 
-const { entries } = Object;
-
 let tsParserVersion;
 try {
   // eslint-disable-next-line import/no-unresolved, global-require
@@ -23,7 +21,7 @@ function minEcmaVersion(features, parserOptions) {
   const result = Math.max(
     ...[].concat(
       (parserOptions && parserOptions.ecmaVersion) || [],
-      entries(minEcmaVersionForFeatures).flatMap((entry) => {
+      Object.entries(minEcmaVersionForFeatures).flatMap((entry) => {
         const f = entry[0];
         const y = entry[1];
         return features.has(f) ? y : [];

--- a/__tests__/__util__/ruleOptionsMapperFactory.js
+++ b/__tests__/__util__/ruleOptionsMapperFactory.js
@@ -2,8 +2,6 @@
  * @flow
  */
 
-const { fromEntries, entries } = Object;
-
 type ESLintTestRunnerTestCase = {
   code: string,
   errors: ?Array<{ message: string, type: string }>,
@@ -23,7 +21,7 @@ export default function ruleOptionsMapperFactory(ruleOptions: Array<mixed> = [])
       code,
       errors,
       // Flatten the array of objects in an array of one object.
-      options: [fromEntries((options || []).concat(ruleOptions).flatMap((item) => entries((item: any))))],
+      options: [Object.fromEntries((options || []).concat(ruleOptions).flatMap((item) => Object.entries((item: any))))],
       parserOptions,
       settings,
     };

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -23,8 +23,6 @@ import isInteractiveElement from '../util/isInteractiveElement';
 import isNonInteractiveRole from '../util/isNonInteractiveRole';
 import isPresentationRole from '../util/isPresentationRole';
 
-const { hasOwn } = Object;
-
 const errorMessage = 'Interactive elements should not be assigned non-interactive roles.';
 
 export default ({
@@ -68,7 +66,7 @@ export default ({
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
+        if (Object.hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -28,8 +28,6 @@ import isNonInteractiveElement from '../util/isNonInteractiveElement';
 import isNonInteractiveRole from '../util/isNonInteractiveRole';
 import isPresentationRole from '../util/isPresentationRole';
 
-const { hasOwn } = Object;
-
 const errorMessage = 'Non-interactive elements should not be assigned mouse or keyboard event listeners.';
 
 const defaultInteractiveProps = [].concat(
@@ -61,7 +59,7 @@ export default ({
         const config = (options[0] || {});
         const interactiveProps = config.handlers || defaultInteractiveProps;
         // Allow overrides from rule configuration for specific elements and roles.
-        if (hasOwn(config, type)) {
+        if (Object.hasOwn(config, type)) {
           attributes = attributes.filter((attr) => attr.type !== 'JSXSpreadAttribute' && !config[type].includes(propName(attr)));
         }
 

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -21,8 +21,6 @@ import getExplicitRole from '../util/getExplicitRole';
 import isNonInteractiveElement from '../util/isNonInteractiveElement';
 import isInteractiveRole from '../util/isInteractiveRole';
 
-const { hasOwn } = Object;
-
 const errorMessage = 'Non-interactive elements should not be assigned interactive roles.';
 
 export default ({
@@ -66,7 +64,7 @@ export default ({
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
+        if (Object.hasOwn(allowedRoles, type) && allowedRoles[type].includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -15,8 +15,6 @@ import getElementType from '../util/getElementType';
 import getExplicitRole from '../util/getExplicitRole';
 import getImplicitRole from '../util/getImplicitRole';
 
-const { hasOwn } = Object;
-
 const errorMessage = (element: string, implicitRole: string) => (
   `The element ${element} has an implicit role of ${implicitRole}. Defining this explicitly is redundant and should be avoided.`
 );
@@ -58,7 +56,7 @@ export default ({
           const allowedRedundantRoles = (options[0] || {});
           let redundantRolesForElement;
 
-          if (hasOwn(allowedRedundantRoles, type)) {
+          if (Object.hasOwn(allowedRedundantRoles, type)) {
             redundantRolesForElement = allowedRedundantRoles[type];
           } else {
             redundantRolesForElement = DEFAULT_ROLE_EXCEPTIONS[type] || [];

--- a/src/util/getElementType.js
+++ b/src/util/getElementType.js
@@ -7,8 +7,6 @@ import { elementType, getProp, getLiteralPropValue } from 'jsx-ast-utils';
 
 import type { ESLintContext } from '../../flow/eslint';
 
-const { hasOwn } = Object;
-
 const getElementType = (context: ESLintContext): ((node: JSXOpeningElement) => string) => {
   const { settings } = context;
   const polymorphicPropName = settings['jsx-a11y']?.polymorphicPropName;
@@ -31,7 +29,7 @@ const getElementType = (context: ESLintContext): ((node: JSXOpeningElement) => s
       return rawType;
     }
 
-    return hasOwn(componentMap, rawType) ? componentMap[rawType] : rawType;
+    return Object.hasOwn(componentMap, rawType) ? componentMap[rawType] : rawType;
   };
 };
 

--- a/src/util/getSuggestion.js
+++ b/src/util/getSuggestion.js
@@ -1,7 +1,5 @@
 import editDistance from 'damerau-levenshtein';
 
-const { fromEntries } = Object;
-
 // Minimum edit distance to be considered a good suggestion.
 const THRESHOLD = 2;
 
@@ -10,7 +8,7 @@ const THRESHOLD = 2;
  * to return.
  */
 export default function getSuggestion(word, dictionary = [], limit = 2) {
-  const distances = fromEntries(
+  const distances = Object.fromEntries(
     dictionary.map((dictionaryWord) => {
       const distance = editDistance(word.toUpperCase(), dictionaryWord.toUpperCase());
       const { steps } = distance;


### PR DESCRIPTION
Introduced in a3c0ffa5, but these are the only places we do this.  
In all other places we use `Object.*`