### PR TITLE
refactor: don't spread arrays

### DIFF
--- a/__mocks__/genInteractives.js
+++ b/__mocks__/genInteractives.js
@@ -12,8 +12,8 @@ import JSXElementMock from './JSXElementMock';
 import type { JSXAttributeMockType } from './JSXAttributeMock';
 import type { JSXElementMockType } from './JSXElementMock';
 
-const domElements = [...dom.keys()];
-const roleNames = [...roles.keys()];
+const domElements = dom.keys();
+const roleNames = roles.keys();
 
 const interactiveElementsMap = {
   a: [{ prop: 'href', value: '#' }],

--- a/__tests__/src/rules/aria-props-test.js
+++ b/__tests__/src/rules/aria-props-test.js
@@ -19,7 +19,7 @@ import getSuggestion from '../../../src/util/getSuggestion';
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
-const ariaAttributes = [...aria.keys()];
+const ariaAttributes = aria.keys();
 
 const errorMessage = (name) => {
   const suggestions = getSuggestion(name, ariaAttributes);

--- a/__tests__/src/rules/aria-role-test.js
+++ b/__tests__/src/rules/aria-role-test.js
@@ -24,7 +24,7 @@ const errorMessage = {
   type: 'JSXAttribute',
 };
 
-const roleKeys = [...roles.keys()];
+const roleKeys = roles.keys();
 
 const validRoles = roleKeys.filter((role) => roles.get(role).abstract === false);
 const invalidRoles = roleKeys.filter((role) => roles.get(role).abstract === true);

--- a/__tests__/src/rules/aria-unsupported-elements-test.js
+++ b/__tests__/src/rules/aria-unsupported-elements-test.js
@@ -26,7 +26,7 @@ Try removing the prop '${invalidProp}'.`,
   type: 'JSXOpeningElement',
 });
 
-const domElements = [...dom.keys()];
+const domElements = dom.keys();
 // Generate valid test cases
 const roleValidityTests = domElements.map((element) => {
   const isReserved = dom.get(element).reserved || false;

--- a/src/rules/aria-props.js
+++ b/src/rules/aria-props.js
@@ -12,7 +12,7 @@ import { propName } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
 import getSuggestion from '../util/getSuggestion';
 
-const ariaAttributes = [...aria.keys()];
+const ariaAttributes = aria.keys();
 
 const errorMessage = (name) => {
   const suggestions = getSuggestion(name, ariaAttributes);

--- a/src/rules/aria-unsupported-elements.js
+++ b/src/rules/aria-unsupported-elements.js
@@ -21,6 +21,8 @@ const errorMessage = (invalidProp) => (
 Try removing the prop '${invalidProp}'.`
 );
 
+const invalidAttributes = new Set(aria.keys().concat('role'));
+
 const schema = generateObjSchema();
 
 export default {
@@ -46,8 +48,6 @@ export default {
         if (isReservedNodeType === false) {
           return;
         }
-
-        const invalidAttributes = new Set([...aria.keys(), 'role']);
 
         node.attributes.forEach((prop) => {
           if (prop.type === 'JSXSpreadAttribute') {

--- a/src/rules/role-has-required-aria-props.js
+++ b/src/rules/role-has-required-aria-props.js
@@ -24,6 +24,8 @@ const errorMessage = (role, requiredProps) => (
 
 const schema = generateObjSchema();
 
+const roleKeys = roles.keys();
+
 export default {
   meta: {
     docs: {
@@ -60,7 +62,7 @@ export default {
 
         const normalizedValues = String(roleAttrValue).toLowerCase().split(' ');
         const validRoles = normalizedValues
-          .filter((val) => [...roles.keys()].indexOf(val) > -1);
+          .filter((val) => roleKeys.indexOf(val) > -1);
 
         // Check semantic DOM elements
         // For example, <input type="checkbox" role="switch" />

--- a/src/util/isInteractiveElement.js
+++ b/src/util/isInteractiveElement.js
@@ -16,7 +16,7 @@ import flatMap from 'array.prototype.flatmap';
 
 import attributesComparator from './attributesComparator';
 
-const roleKeys = [...roles.keys()];
+const roleKeys = roles.keys();
 const elementRoleEntries = [...elementRoles];
 
 const nonInteractiveRoles = new Set(roleKeys

--- a/src/util/isInteractiveRole.js
+++ b/src/util/isInteractiveRole.js
@@ -5,7 +5,7 @@ import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
 import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 
-const roles = [...rolesMap.keys()];
+const roles = rolesMap.keys();
 const interactiveRoles = roles.filter((name) => (
   !rolesMap.get(name).abstract
   && rolesMap.get(name).superClass.some((klasses) => includes(klasses, 'widget'))

--- a/src/util/isNonInteractiveElement.js
+++ b/src/util/isNonInteractiveElement.js
@@ -17,7 +17,7 @@ import flatMap from 'array.prototype.flatmap';
 
 import attributesComparator from './attributesComparator';
 
-const roleKeys = [...roles.keys()];
+const roleKeys = roles.keys();
 const elementRoleEntries = [...elementRoles];
 
 const nonInteractiveRoles = new Set(roleKeys

--- a/src/util/isNonInteractiveRole.js
+++ b/src/util/isNonInteractiveRole.js
@@ -11,7 +11,7 @@ import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
 import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 
-const nonInteractiveRoles = [...rolesMap.keys()].filter((name) => (
+const nonInteractiveRoles = rolesMap.keys().filter((name) => (
   !rolesMap.get(name).abstract
   && !rolesMap.get(name).superClass.some((klasses) => includes(klasses, 'widget'))
 ));


### PR DESCRIPTION
Same reason as mentioned in #1030: `*.keys()` & `*.entries()` is an array, so no need to spread them anymore