### PR TITLE
[Fix] fix unstable plugin reference with flat configs

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -38,3 +38,12 @@ test('schemas', (t) => {
 
   t.end();
 });
+
+test('plugin referentially equal to prevent flat config issues', (t) => {
+  const keys = Object.keys(plugin.flatConfigs);
+  for (let i = 0; i < keys.length; i += 1) {
+    const config = plugin.flatConfigs[keys[i]];
+    t.equal(plugin, config.plugins['jsx-a11y'], `${config.name}'s plugin reference is referentially equal to the top-level export`);
+  }
+  t.end();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -317,4 +317,4 @@ const flatConfigs = {
   strict: createConfig(strictRules, 'strict'),
 };
 
-module.exports = { ...jsxA11y, configs, flatConfigs };
+module.exports = Object.assign(jsxA11y, { configs, flatConfigs });


### PR DESCRIPTION
The previous use of spread meant that
```ts
import jsxA11y from 'eslint-plugin-jsx-a11y';

jsxA11y !== jsxA11y.flatConfigs.recommended.plugins['jsx-a11y']
```

This is a problem because if someone does something like this 
```js
import jsxA11y from 'eslint-plugin-jsx-a11y';

export default [
  { plugins: { 'jsx-a11y': jsxA11y } },
  jsxA11y.flatConfigs.recommended,
];
```
then ESLint will crash with the error `Config "jsx-a11y/recommended": Key "plugins": Cannot redefine plugin "jsx-a11y".`

This PR fixes that by using `Object.assign` to mutate the `jsxA11y` object and maintain referential equality.