### PR TITLE
docs: fix a typo in `aria-role.md`

### DIFF
--- a/docs/rules/aria-role.md
+++ b/docs/rules/aria-role.md
@@ -21,7 +21,7 @@ This rule takes one optional object argument of type object:
 }
 ```
 
-`allowedInvalidRules` is an optional string array of custom roles that should be allowed in addition to the ARIA spec, such as for cases when you [need to use a non-standard role](https://axesslab.com/text-splitting).
+`allowedInvalidRoles` is an optional string array of custom roles that should be allowed in addition to the ARIA spec, such as for cases when you [need to use a non-standard role](https://axesslab.com/text-splitting).
 
 For the `ignoreNonDOM` option, this determines if developer created components are checked.
 


### PR DESCRIPTION
Hello,

I've fixed a typo. `allowedInvalidRules` -> `allowedInvalidRoles`