### PR TITLE
JSDoc: Mark `createConfig`'s `flatConfigName` parameter as optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -293,7 +293,7 @@ const jsxA11y = {
 /**
  * Given a ruleset and optionally a flat config name, generate a config.
  * @param {object} rules - ruleset for this config
- * @param {string} flatConfigName - name for the config if flat
+ * @param {string} [flatConfigName] - name for the config if flat
  * @returns Config for this set of rules.
  */
 const createConfig = (rules, flatConfigName) => ({


### PR DESCRIPTION
`createConfig` is called below with a single parameter, so it seems it is intended to be optional.

Other than having slightly more accurate doc, why does this matter? To my grand surprise, this actually affected my code.
I have an application in pure JS where the team isn't quite ready to "do the big jump" to Typescript yet (it's planned, just not a priority migration). So I've been slowly introducing additional type information through TSDoc comments. I also configured `jsconfig.json` to configure VSCode and have an optional `tsc` command so we can follow on the progress.

So I end up in the very specific scenario where a pure JS project is typed-checked (with `"checkJs": true`), and a lib (`eslint-plugin-jsx-a11y`) without `.d.ts` file makes `"skipLibCheck": true` and `"exclude": ["node_modules"]` useless, so the source has to be checked if imported...
<img width="350" alt="image" src="https://github.com/user-attachments/assets/afa6b083-c625-4e3f-bc23-bffe96982589" /> <img width="350" alt="image" src="https://github.com/user-attachments/assets/c8e475ee-7b6b-4b36-a9e3-4cf1f27e0f58" />
<img width="652" height="295" alt="image" src="https://github.com/user-attachments/assets/89cb2ff8-6055-4486-9ad7-e7f094df6eca" />

For reference, here's the `jsconfig.json` to show I can't "configure this error away":
```json
{
  "extends": ["eslint-config-beslogic/tsconfig.5.6.json"],
  "compilerOptions": {
    "strict": false, // Least strict possible
    "noUncheckedIndexedAccess": false, // Least strict possible
    // "strictNullChecks": true, // Stop hiding null/undefined types // TODO: Enable later
    "incremental": true, // Performance improvement during dev through incremental checking
    "checkJs": true, // Stop hiding null/undefined types
    "jsx": "preserve", // next.js implements its own optimized jsx transform
    "esModuleInterop": true, // Necessary for import.meta in mjs files
    "moduleResolution": "bundler",
    "baseUrl": ".",
    "paths": {
      "@/*": ["./*"]
    },
    "skipLibCheck": true
  },
  "exclude": ["node_modules", "public"]
}
```