### PR TITLE
fix(img-redundant-alt): only flag alts that are purely redundant or use 'word of' prefix

### DIFF
--- a/__tests__/src/rules/img-redundant-alt-test.js
+++ b/__tests__/src/rules/img-redundant-alt-test.js
@@ -103,16 +103,18 @@ ruleTester.run('img-redundant-alt', rule, {
     { code: '<img alt="passport photo ID" />' },
     { code: '<img alt="before and after photo collage" />' },
     { code: '<img alt="satellite image overlay" />' },
+    { code: '<img alt="Picture Perfect album cover" />' },
+    { code: '<img alt="Photo finish at 100m race" />' },
+    { code: '<img alt="Photo booth selfie" />' },
+    { code: '<img alt="body image awareness poster" />' },
+
 
     // -------------------------------------------------------------------
     // Template literals with non-redundant context words
     // -------------------------------------------------------------------
     { code: '<img alt={`picture doing ${things}`} {...this.props} />' },
-    { code: '<img alt={`photo doing ${things}`} {...this.props} />' },
-    { code: '<img alt={`image doing ${things}`} {...this.props} />' },
-    { code: '<img alt={`picture doing ${picture}`} {...this.props} />' },
-    { code: '<img alt={`photo doing ${photo}`} {...this.props} />' },
-    { code: '<img alt={`image doing ${image}`} {...this.props} />' },
+    { code: '<img alt={`Book cover photo ${index} of ${total}`} {...this.props} />' },
+    { code: '<img alt={`${dockerImageName} image running`} {...this.props} />' },
 
     // -------------------------------------------------------------------
     // Custom component not mapped to img — Image is not validated by default

--- a/__tests__/src/rules/img-redundant-alt-test.js
+++ b/__tests__/src/rules/img-redundant-alt-test.js
@@ -108,7 +108,6 @@ ruleTester.run('img-redundant-alt', rule, {
     { code: '<img alt="Photo booth selfie" />' },
     { code: '<img alt="body image awareness poster" />' },
 
-
     // -------------------------------------------------------------------
     // Template literals with non-redundant context words
     // -------------------------------------------------------------------

--- a/__tests__/src/rules/img-redundant-alt-test.js
+++ b/__tests__/src/rules/img-redundant-alt-test.js
@@ -33,16 +33,25 @@ const componentsSettings = {
 
 const ruleTester = new RuleTester();
 
-const expectedError = {
-  message: 'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.',
+// Fired when the entire alt is nothing but redundant words — no useful content at all.
+const redundantAltError = {
+  messageId: 'redundantAlt',
+  type: 'JSXOpeningElement',
+};
+
+// Fired when the alt opens with a redundant word followed by "of" — the prefix adds
+// nothing over the screen-reader's own announcement; the description after "of" is enough.
+const redundantAltPrefixError = {
+  messageId: 'redundantAltPrefix',
   type: 'JSXOpeningElement',
 };
 
 ruleTester.run('img-redundant-alt', rule, {
   valid: parsers.all([].concat(
+    // -------------------------------------------------------------------
+    // Baseline — unrelated or variable alts
+    // -------------------------------------------------------------------
     { code: '<img alt="foo" />;' },
-    { code: '<img alt="picture of me taking a photo of an image" aria-hidden />' },
-    { code: '<img aria-hidden alt="photo of image" />' },
     { code: '<img ALt="foo" />;' },
     { code: '<img {...this.props} alt="foo" />' },
     { code: '<img {...this.props} alt={"foo"} />' },
@@ -70,68 +79,112 @@ ruleTester.run('img-redundant-alt', rule, {
       { code: '<img alt={imageAlt?.name} />', languageOptions: { ecmaVersion: 2020 } },
       { code: '<img alt="Doing cool things" aria-hidden={foo?.bar}/>', languageOptions: { ecmaVersion: 2020 } },
     ] : [],
+
+    // -------------------------------------------------------------------
+    // Words that contain a redundant substring but are not the word itself
+    // -------------------------------------------------------------------
     { code: '<img alt="Photography" />;' },
     { code: '<img alt="ImageMagick" />;' },
+
+    // -------------------------------------------------------------------
+    // aria-hidden — rule never fires regardless of alt content
+    // -------------------------------------------------------------------
+    { code: '<img alt="picture of me taking a photo of an image" aria-hidden />' },
+    { code: '<img aria-hidden alt="photo of image" />' },
+
+    // -------------------------------------------------------------------
+    // Compound nouns and descriptive labels: redundant word is part of a
+    // meaningful phrase, NOT a bare announcement of image type.
+    // "disk image", "profile photo", "cover picture" all convey real info.
+    // -------------------------------------------------------------------
+    { code: '<img alt="disk image" />' },
+    { code: '<img alt="profile photo" />' },
+    { code: '<img alt="cover picture" />' },
+    { code: '<img alt="passport photo ID" />' },
+    { code: '<img alt="before and after photo collage" />' },
+    { code: '<img alt="satellite image overlay" />' },
+
+    // -------------------------------------------------------------------
+    // Template literals with non-redundant context words
+    // -------------------------------------------------------------------
+    { code: '<img alt={`picture doing ${things}`} {...this.props} />' },
+    { code: '<img alt={`photo doing ${things}`} {...this.props} />' },
+    { code: '<img alt={`image doing ${things}`} {...this.props} />' },
+    { code: '<img alt={`picture doing ${picture}`} {...this.props} />' },
+    { code: '<img alt={`photo doing ${photo}`} {...this.props} />' },
+    { code: '<img alt={`image doing ${image}`} {...this.props} />' },
+
+    // -------------------------------------------------------------------
+    // Custom component not mapped to img — Image is not validated by default
+    // -------------------------------------------------------------------
     { code: '<Image alt="Photo of a friend" />' },
     { code: '<Image alt="Foo" />', settings: componentsSettings },
+
+    // -------------------------------------------------------------------
+    // Non-ASCII: only exact-word matches are flagged
+    // -------------------------------------------------------------------
     { code: '<img alt="画像" />', options: [{ words: ['イメージ'] }] },
+    { code: '<img alt="イメージです" />', options: [{ words: ['イメージ'] }] },
   )).map(parserOptionsMapper),
+
   invalid: parsers.all([].concat(
-    { code: '<img alt="Photo of friend." />;', errors: [expectedError] },
-    { code: '<img alt="Picture of friend." />;', errors: [expectedError] },
-    { code: '<img alt="Image of friend." />;', errors: [expectedError] },
-    { code: '<img alt="PhOtO of friend." />;', errors: [expectedError] },
-    { code: '<img alt={"photo"} />;', errors: [expectedError] },
-    { code: '<img alt="piCTUre of friend." />;', errors: [expectedError] },
-    { code: '<img alt="imAGE of friend." />;', errors: [expectedError] },
+    // -------------------------------------------------------------------
+    // Pure redundant alts — the entire alt is one or more redundant words,
+    // conveying nothing a screen-reader doesn't already announce.
+    // -------------------------------------------------------------------
+    { code: '<img alt={"photo"} />;', errors: [redundantAltError] },
+    { code: '<img alt="photo" {...this.props} />', errors: [redundantAltError] },
+    { code: '<img alt="image" {...this.props} />', errors: [redundantAltError] },
+    { code: '<img alt="picture" {...this.props} />', errors: [redundantAltError] },
+
+    // -------------------------------------------------------------------
+    // "word of ..." prefix — redundant word + "of" adds no meaning over
+    // the screen-reader announcement; only the description after "of" matters.
+    // -------------------------------------------------------------------
+    { code: '<img alt="Photo of friend." />;', errors: [redundantAltPrefixError] },
+    { code: '<img alt="Picture of friend." />;', errors: [redundantAltPrefixError] },
+    { code: '<img alt="Image of friend." />;', errors: [redundantAltPrefixError] },
+    { code: '<img alt="PhOtO of friend." />;', errors: [redundantAltPrefixError] },
+    { code: '<img alt="piCTUre of friend." />;', errors: [redundantAltPrefixError] },
+    { code: '<img alt="imAGE of friend." />;', errors: [redundantAltPrefixError] },
     {
       code: '<img alt="photo of cool person" aria-hidden={false} />',
-      errors: [expectedError],
+      errors: [redundantAltPrefixError],
     },
     {
       code: '<img alt="picture of cool person" aria-hidden={false} />',
-      errors: [expectedError],
+      errors: [redundantAltPrefixError],
     },
     {
       code: '<img alt="image of cool person" aria-hidden={false} />',
-      errors: [expectedError],
+      errors: [redundantAltPrefixError],
     },
-    { code: '<img alt="photo" {...this.props} />', errors: [expectedError] },
-    { code: '<img alt="image" {...this.props} />', errors: [expectedError] },
-    { code: '<img alt="picture" {...this.props} />', errors: [expectedError] },
-    {
-      code: '<img alt={`picture doing ${things}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    {
-      code: '<img alt={`photo doing ${things}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    {
-      code: '<img alt={`image doing ${things}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    {
-      code: '<img alt={`picture doing ${picture}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    {
-      code: '<img alt={`photo doing ${photo}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    {
-      code: '<img alt={`image doing ${image}`} {...this.props} />',
-      errors: [expectedError],
-    },
-    { code: '<Image alt="Photo of a friend" />', errors: [expectedError], settings: componentsSettings },
+    // Demonstrates the value of the prefix check: "image of a diagram" should
+    // just be "diagram" — the "image of" is pure noise for a screen-reader user.
+    { code: '<img alt="image of a diagram" />', errors: [redundantAltPrefixError] },
+    { code: '<img alt="photo of the building entrance" />', errors: [redundantAltPrefixError] },
+    { code: '<img alt="picture of a flow chart" />', errors: [redundantAltPrefixError] },
 
-    // TESTS FOR ARRAY OPTION TESTS
-    { code: '<img alt="Word1" />;', options: array, errors: [expectedError] },
-    { code: '<img alt="Word2" />;', options: array, errors: [expectedError] },
-    { code: '<Image alt="Word1" />;', options: array, errors: [expectedError] },
-    { code: '<Image alt="Word2" />;', options: array, errors: [expectedError] },
+    // -------------------------------------------------------------------
+    // Custom component mapped to img via settings
+    // -------------------------------------------------------------------
+    {
+      code: '<Image alt="Photo of a friend" />',
+      errors: [redundantAltPrefixError],
+      settings: componentsSettings,
+    },
 
-    { code: '<img alt="イメージ" />', options: [{ words: ['イメージ'] }], errors: [expectedError] },
-    { code: '<img alt="イメージです" />', options: [{ words: ['イメージ'] }], errors: [expectedError] },
+    // -------------------------------------------------------------------
+    // Custom words option
+    // -------------------------------------------------------------------
+    { code: '<img alt="Word1" />;', options: array, errors: [redundantAltError] },
+    { code: '<img alt="Word2" />;', options: array, errors: [redundantAltError] },
+    { code: '<Image alt="Word1" />;', options: array, errors: [redundantAltError] },
+    { code: '<Image alt="Word2" />;', options: array, errors: [redundantAltError] },
+
+    // -------------------------------------------------------------------
+    // Non-ASCII exact-word match
+    // -------------------------------------------------------------------
+    { code: '<img alt="イメージ" />', options: [{ words: ['イメージ'] }], errors: [redundantAltError] },
   )).map(parserOptionsMapper),
 });

--- a/src/rules/img-redundant-alt.js
+++ b/src/rules/img-redundant-alt.js
@@ -9,7 +9,6 @@
 
 import { getProp, getLiteralPropValue } from 'jsx-ast-utils';
 import includes from 'array-includes';
-import stringIncludes from 'string.prototype.includes';
 import safeRegexTest from 'safe-regex-test';
 import { generateObjSchema, arraySchema } from '../util/schemas';
 import getElementType from '../util/getElementType';
@@ -21,8 +20,6 @@ const REDUNDANT_WORDS = [
   'picture',
 ];
 
-const errorMessage = 'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.';
-
 const schema = generateObjSchema({
   components: arraySchema,
   words: arraySchema,
@@ -30,13 +27,28 @@ const schema = generateObjSchema({
 
 const isASCII = safeRegexTest(/[\x20-\x7F]+/);
 
-function containsRedundantWord(value, redundantWords) {
-  const lowercaseRedundantWords = redundantWords.map((redundantWord) => redundantWord.toLowerCase());
+function getWords(value) {
+  return value.split(/\s+/).filter((w) => w.length > 0);
+}
 
-  if (isASCII(value)) {
-    return value.split(/\s+/).some((valueWord) => includes(lowercaseRedundantWords, valueWord.toLowerCase()));
-  }
-  return lowercaseRedundantWords.some((redundantWord) => stringIncludes(value.toLowerCase(), redundantWord));
+// Flags alts whose every word is a redundant word, e.g. "image", "photo picture".
+// Compound nouns like "disk image" or "profile photo" are intentionally allowed.
+function isOnlyRedundantWords(value, redundantWords) {
+  const lowerRedundant = redundantWords.map((w) => w.toLowerCase());
+  const words = getWords(value);
+  return words.length > 0 && words.every((w) => includes(lowerRedundant, w.toLowerCase()));
+}
+
+// Flags alts that open with a redundant word followed by "of", e.g. "image of a cat".
+// The "of X" phrasing contributes no additional meaning over the screen-reader announcement.
+function startsWithRedundantWordOf(value, redundantWords) {
+  const lowerRedundant = redundantWords.map((w) => w.toLowerCase());
+  const words = getWords(value);
+  return (
+    words.length >= 2
+    && includes(lowerRedundant, words[0].toLowerCase())
+    && words[1].toLowerCase() === 'of'
+  );
 }
 
 export default {
@@ -44,6 +56,10 @@ export default {
     docs: {
       url: 'https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/img-redundant-alt.md',
       description: 'Enforce `<img>` alt prop does not contain the word "image", "picture", or "photo".',
+    },
+    messages: {
+      redundantAlt: 'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don\'t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.',
+      redundantAltPrefix: 'Redundant alt prefix. Screen-readers already announce `img` tags as an image. Remove the leading "image of", "photo of", or "picture of" prefix — the descriptive part that follows is sufficient.',
     },
     schema: [schema],
   },
@@ -57,7 +73,7 @@ export default {
         const typesToValidate = ['img'].concat(componentOptions);
         const nodeType = elementType(node);
 
-        // Only check 'label' elements and custom types.
+        // Only check 'img' elements and custom types.
         if (typesToValidate.indexOf(nodeType) === -1) {
           return;
         }
@@ -77,13 +93,18 @@ export default {
         const redundantWords = REDUNDANT_WORDS.concat(words);
 
         if (typeof value === 'string' && isVisible) {
-          const hasRedundancy = containsRedundantWord(value, redundantWords);
-
-          if (hasRedundancy === true) {
-            context.report({
-              node,
-              message: errorMessage,
-            });
+          if (isASCII(value)) {
+            if (isOnlyRedundantWords(value, redundantWords)) {
+              context.report({ node, messageId: 'redundantAlt' });
+            } else if (startsWithRedundantWordOf(value, redundantWords)) {
+              context.report({ node, messageId: 'redundantAltPrefix' });
+            }
+          } else {
+            // For non-ASCII text, flag only when the entire value is itself a redundant word.
+            const lowerValue = value.trim().toLowerCase();
+            if (redundantWords.map((w) => w.toLowerCase()).some((rw) => lowerValue === rw)) {
+              context.report({ node, messageId: 'redundantAlt' });
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

The current rule flags any `alt` text that contains the words `image`, `photo`, or `picture` anywhere — which produces false positives for legitimate, descriptive alt text like `"disk image"`, `"profile photo"`, or `"satellite image overlay"`. These compound nouns carry real meaning and should not be flagged. 

This PR tightens the rule to two specific cases that are genuinely unhelpful to screen-reader users:

1. **Purely redundant alts** — the entire alt is nothing but redundant words (e.g. `alt="image"`, `alt="photo"`). These are flagged as before.
2. **"word of …" prefix** — the alt opens with a redundant word followed by `"of"` (e.g. `alt="image of a cat"`). Screen-readers already announce the element as an image; the `"image of"` prefix adds nothing — only the description after it matters. These are flagged with a separate, softer message so they can be configured at a different severity in consumer ESLint configs. I am very open to other words, like "showing," but even that one I feel could mean showing in the figurative sense.. 

Everything else — compound nouns, descriptive labels that happen to include one of the words, template literals with meaningful context — is left alone.

## Changes

- `src/rules/img-redundant-alt.js`
  - Removed unused `stringIncludes` import
  - Replaced single `containsRedundantWord` check with two named functions (`isOnlyRedundantWords`, `startsWithRedundantWordOf`) that encode the intent explicitly
  - Switched to `messages` + `messageId` in `meta` so each case can be configured at different severity levels
  - Non-ASCII path now requires an exact whole-value match (previously used substring match, which would flag words like `"imagery"`)

- `__tests__/src/rules/img-redundant-alt-test.js`
  - Updated error assertions to use `messageId` instead of hardcoded message strings
  - Moved template-literal-with-context cases (`picture doing ${things}` etc.) to `valid`
  - Added valid cases demonstrating meaningful compound alt text: `"disk image"`, `"profile photo"`, `"cover picture"`, `"satellite image overlay"`, etc.
  - Added invalid cases for the new `"word of"` prefix check with explanatory comments

See here for some examples of alt texts that I believe should be entirely valid: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/1085/changes#diff-c42207e7115fb61778d9d614ea8a38b2af9bcaefd070f14014c73716fcb05bb5R100-R110

All 38,607 existing tests pass.

## Motivation

The rule as written is commonly perceived as overly aggressive. A rule that fires on `alt="disk image"` or `alt="passport photo ID"` trains developers to ignore or disable it (or just use a workaround like replacing "photo" with "photograph" rather than write better alt text — the opposite of the intended effect. Tightening the signal improves compliance with the cases that actually matter.

Additionally, after searching the Issues on this repo, it seems others years ago had similar thoughts: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/417
