### PR TITLE
[Fix] no-static-element-interactions, no-noninteractive-tabindex: add allowExpressionValues to schema

### DIFF
--- a/src/rules/no-noninteractive-tabindex.js
+++ b/src/rules/no-noninteractive-tabindex.js
@@ -34,6 +34,9 @@ const schema = generateObjSchema({
     ...arraySchema,
     description: 'An array of HTML tag names',
   },
+  allowExpressionValues: {
+    type: 'boolean',
+  },
 });
 
 export default ({

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -37,6 +37,9 @@ const defaultInteractiveProps = [].concat(
 );
 const schema = generateObjSchema({
   handlers: arraySchema,
+  allowExpressionValues: {
+    type: 'boolean',
+  },
 });
 
 export default ({


### PR DESCRIPTION
Fixes #1073.
Both no-static-element-interactions and no-noninteractive-tabindex destructure allowExpressionValues from options[0] and use it to determine whether non-literal role expressions should be allowed. The option is documented in both rules' docs, tested in both rules' test suites, and included in the recommended configuration examples.
However, neither rule declares allowExpressionValues in its JSON schema. This means ESLint rejects the option during config validation when additionalProperties checking is applied, even though the rule code handles it correctly.

Changes:
Add allowExpressionValues: { type: 'boolean' } to the schema for no-static-element-interactions
Add allowExpressionValues: { type: 'boolean' } to the schema for no-noninteractive-tabindex

No behavioral change. Existing tests pass unmodified