### PR TITLE
[patch] lang: add htmlHasLang option

### DIFF
--- a/__tests__/src/rules/lang-test.js
+++ b/__tests__/src/rules/lang-test.js
@@ -52,6 +52,7 @@ ruleTester.run('lang', rule, {
     { code: '<HTML lang="foo" />' },
     { code: '<Foo lang={undefined} />' },
     { code: '<html lang={undefined} />' },
+    { code: '<html lang={foo} />', options: [{ htmlHasLang: true }] },
     { code: '<Foo lang={undefined} />', settings: componentsSettings },
     { code: '<Foo lang="en" />', settings: componentsSettings },
     { code: '<Box as="html" lang="en"  />', settings: componentsSettings },
@@ -63,6 +64,10 @@ ruleTester.run('lang', rule, {
     { code: '<html lang="zz-LL" />', errors: [expectedError] },
     { code: '<Box as="html" lang="foo" />', settings: componentsSettings, errors: [expectedError] },
     { code: '<html />', options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError] },
+    { code: '<html lang={undefined} />', options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError] },
+    {
+      code: '<Foo lang={undefined} />', settings: componentsSettings, options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError],
+    },
     {
       code: '<Foo />', settings: componentsSettings, options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError],
     },

--- a/__tests__/src/rules/lang-test.js
+++ b/__tests__/src/rules/lang-test.js
@@ -7,10 +7,10 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-import RuleTester from '../../__util__/RuleTester';
-import parserOptionsMapper from '../../__util__/parserOptionsMapper';
-import parsers from '../../__util__/helpers/parsers';
 import rule from '../../../src/rules/lang';
+import RuleTester from '../../__util__/RuleTester';
+import parsers from '../../__util__/helpers/parsers';
+import parserOptionsMapper from '../../__util__/parserOptionsMapper';
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -20,7 +20,12 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: 'lang attribute must have a valid value.',
-  type: 'JSXAttribute',
+  type: 'JSXOpeningElement',
+};
+
+const expectedHtmlHasLangError = {
+  message: '<html> elements must have the lang prop.',
+  type: 'JSXOpeningElement',
 };
 
 const componentsSettings = {
@@ -46,14 +51,21 @@ ruleTester.run('lang', rule, {
     { code: '<html lang={foo} />' },
     { code: '<HTML lang="foo" />' },
     { code: '<Foo lang={undefined} />' },
+    { code: '<html lang={undefined} />' },
+    { code: '<Foo lang={undefined} />', settings: componentsSettings },
     { code: '<Foo lang="en" />', settings: componentsSettings },
     { code: '<Box as="html" lang="en"  />', settings: componentsSettings },
+    { code: '<html />', options: [{ htmlHasLang: false }] },
+    { code: '<Foo />', settings: componentsSettings, options: [{ htmlHasLang: false }] },
   )).map(parserOptionsMapper),
   invalid: parsers.all([].concat(
     { code: '<html lang="foo" />', errors: [expectedError] },
     { code: '<html lang="zz-LL" />', errors: [expectedError] },
-    { code: '<html lang={undefined} />', errors: [expectedError] },
-    { code: '<Foo lang={undefined} />', settings: componentsSettings, errors: [expectedError] },
     { code: '<Box as="html" lang="foo" />', settings: componentsSettings, errors: [expectedError] },
+    { code: '<html />', options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError] },
+    {
+      code: '<Foo />', settings: componentsSettings, options: [{ htmlHasLang: true }], errors: [expectedHtmlHasLangError],
+    },
+    { code: '<html lang="foo" />', options: [{ htmlHasLang: true }], errors: [expectedError] },
   )).map(parserOptionsMapper),
 });

--- a/docs/rules/lang.md
+++ b/docs/rules/lang.md
@@ -3,23 +3,39 @@
 <!-- end auto-generated rule header -->
 
 The `lang` prop on the `<html>` element must be a valid IETF's BCP 47 language tag.
+And also, `<html>` elements must have the `lang` prop.
 
 ## Rule details
 
 This rule takes no arguments.
+
+## Rule options
+
+This rule takes one optional boolean that determines whether to check for the `lang` prop on `<html>` elements. It defaults to `false`:
+
+```json
+{
+    "rules": {
+        "jsx-a11y/lang": [ 2, {
+            "htmlHasLang": true
+        }]
+    }
+}
+```
 
 ### Succeed
 
 ```jsx
 <html lang="en">
 <html lang="en-US">
+<html lang={lang}>
 ```
 
 ### Fail
 
 ```jsx
-<html>
 <html lang="foo">
+<html> // if htmlHasLang is true
 ```
 
 ## Accessibility guidelines

--- a/docs/rules/lang.md
+++ b/docs/rules/lang.md
@@ -16,7 +16,7 @@ This rule takes one optional boolean that determines whether to check for the `l
 ```json
 {
     "rules": {
-        "jsx-a11y/lang": [ 2, {
+        "jsx-a11y/lang": [2, {
             "htmlHasLang": true
         }]
     }

--- a/src/rules/lang.js
+++ b/src/rules/lang.js
@@ -1,22 +1,31 @@
 /**
  * @fileoverview Enforce lang attribute has a valid value.
  * @author Ethan Cohen
+ * @flow
  */
 
 // ----------------------------------------------------------------------------
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-import { propName, getLiteralPropValue } from 'jsx-ast-utils';
+import { getLiteralPropValue, getProp } from 'jsx-ast-utils';
 import tags from 'language-tags';
-import { generateObjSchema } from '../util/schemas';
+import type { JSXOpeningElement } from 'ast-types-flow';
+import type { ESLintConfig, ESLintContext, ESLintVisitorSelectorConfig } from '../../flow/eslint';
 import getElementType from '../util/getElementType';
+import { generateObjSchema } from '../util/schemas';
 
-const errorMessage = 'lang attribute must have a valid value.';
+const htmlHasLangErrorMessage = '<html> elements must have the lang prop.';
+const langErrorMessage = 'lang attribute must have a valid value.';
 
-const schema = generateObjSchema();
+const schema = generateObjSchema({
+  htmlHasLang: {
+    type: 'boolean',
+    default: false,
+  },
+});
 
-export default {
+export default ({
   meta: {
     docs: {
       url: 'https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/lang.md',
@@ -25,45 +34,44 @@ export default {
     schema: [schema],
   },
 
-  create: (context) => {
+  create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
     const elementType = getElementType(context);
     return {
-      JSXAttribute: (node) => {
-        const name = propName(node);
-        if (name && name.toUpperCase() !== 'LANG') {
-          return;
-        }
+      JSXOpeningElement: (node: JSXOpeningElement) => {
+        const checkHtmlHasLang = context.options[0]?.htmlHasLang ?? false;
+        const langProp = getProp(node.attributes, 'lang');
+        const langPropVal = getLiteralPropValue(langProp);
+        const type = elementType(node);
 
-        const { parent } = node;
-        const type = elementType(parent);
         if (type && type !== 'html') {
           return;
         }
 
-        const value = getLiteralPropValue(node);
-
-        // Don't check identifiers
-        if (value === null) {
-          return;
-        }
-        if (value === undefined) {
+        if (checkHtmlHasLang && langProp === undefined) {
           context.report({
             node,
-            message: errorMessage,
+            message: htmlHasLangErrorMessage,
           });
-
           return;
         }
 
-        if (tags.check(value)) {
+        // Don't check identifiers
+        if (langPropVal === null) {
+          return;
+        }
+        if (langProp === undefined || langPropVal === undefined) {
+          return;
+        }
+
+        if (tags.check(langPropVal)) {
           return;
         }
 
         context.report({
           node,
-          message: errorMessage,
+          message: langErrorMessage,
         });
       },
     };
   },
-};
+}: ESLintConfig);

--- a/src/rules/lang.js
+++ b/src/rules/lang.js
@@ -40,14 +40,14 @@ export default ({
       JSXOpeningElement: (node: JSXOpeningElement) => {
         const checkHtmlHasLang = context.options[0]?.htmlHasLang ?? false;
         const langProp = getProp(node.attributes, 'lang');
-        const langPropVal = getLiteralPropValue(langProp);
+        const value = getLiteralPropValue(langProp);
         const type = elementType(node);
 
         if (type && type !== 'html') {
           return;
         }
 
-        if (checkHtmlHasLang && langProp === undefined) {
+        if (checkHtmlHasLang && (langProp === undefined || value === undefined)) {
           context.report({
             node,
             message: htmlHasLangErrorMessage,
@@ -56,14 +56,14 @@ export default ({
         }
 
         // Don't check identifiers
-        if (langPropVal === null) {
+        if (value === null) {
           return;
         }
-        if (langProp === undefined || langPropVal === undefined) {
+        if (langProp === undefined || value === undefined) {
           return;
         }
 
-        if (tags.check(langPropVal)) {
+        if (tags.check(value)) {
           return;
         }
 


### PR DESCRIPTION
close https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1087

~~I worked two things, and this is a breaking change because `lang` rule will do additional checks once this is released.
The latter is not mentioned on the above issue, but I want to introduce this change (if needed, divide changes into another PR).~~

- add option to whether to check `lang` prop for `<html>` element
- ~~check other HTML elements other than `<html>` whether its `lang` prop is valid or not~~